### PR TITLE
Docs: Add Linux virtual environment instructions-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,14 @@ GEN_AI_KEY=your_google_ai_studio_api_key_here
 # Replace each placeholder with the actual values from Step #2
 
 # 4. Create and activate virtual environment
-python -m venv venv
-# On Mac: source venv/bin/activate
+
+# On Mac/Linux: 
+python3 -m venv venv   #create env
+source venv/bin/activate  #activate env
+
 # On Windows: venv\Scripts\activate
+python -m venv venv   #create env 
+venv\Scripts\activate  #activate env
 
 # 5. Install dependencies
 pip install -r requirements.txt


### PR DESCRIPTION
## Description
I noticed that the `README.md` provided setup instructions for macOS and Windows but missed explicit instructions for Linux users as mentioned in the FIXES #36 

Since modern Linux distributions often require `python3` and share the `source` command with macOS, I have updated the "Create and activate virtual environment" section to:
1. Explicitly include Linux in the header.
2. Standardize the commands for macOS/Linux users.

## Changes Made
- Updated the virtual environment setup commands to clearly distinguish between Unix-based systems (Linux/macOS) and Windows.
- Added `python3` command support for Linux/macOS users to prevent default Python version errors.

## Checklist
- [x] I have performed a self-review of my own code (docs).
- [x] My changes generate no new warnings.