### PR TITLE
BugFix: Loading .env breaks on Windows -- strict locate in backend/ root

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,20 +1,21 @@
-import os
 from pathlib import Path
 from dotenv import load_dotenv
 import logging
+import sys, os
 
 logger = logging.getLogger(__name__)
 
-# Load environment variables from a .env file located next to this config module
-dotenv_path = Path(__file__).resolve().parent / ".env"
-if dotenv_path.exists():
-    load_dotenv(dotenv_path)
-    logger.debug(f"Loaded environment variables from {dotenv_path}")
-else:
-    # Fall back to the default behavior (cwd .env or system envs)
-    load_dotenv()
-    logger.debug("No local .env found next to config.py; falling back to default load_dotenv()")
+# Backend root is the expected location of .env
+ROOT_DIR = Path(__file__).resolve().parent.parent  # core/ -> backend/
+dotenv_path = ROOT_DIR / ".env"
 
+if not dotenv_path.exists():
+    logger.error(f".env file not found at expected location: {dotenv_path}")
+    sys.exit(1)  # fail fast, so contributors know immediately
+
+# Load environment variables from backend root/.env
+load_dotenv(dotenv_path)
+logger.debug(f"Loaded environment variables from {dotenv_path}")
 
 class Settings:
     SUPABASE_URL: str = os.getenv("SUPABASE_URL")
@@ -31,7 +32,5 @@ class Settings:
     @property
     def supabase_key(self) -> str:
         return self.SUPABASE_KEY
-
-
 
 config = Settings()


### PR DESCRIPTION
### Changes

- Updated `core/config.py` to always load `.env` from the backend root (`backend/.env`)
- Removed fallback to current working directory (CWD)
- Fail fast with `sys.exit(1)` if `.env` is missing
- Added logging to indicate which `.env` file is loaded

### Motivation

Previously, `.env` loading was relative to `core/` with a fallback to CWD:

- Worked on Mac/Linux if CWD happened to include `.env`
- Broke on Windows if `.env` was only in backend root

This caused fragile, platform-dependent behavior. The update ensures:

- Cross-platform safety (Mac, Linux, Windows)
- Clear, immediate feedback if `.env` is missing
- Standardized location for `.env` in backend root

### How to Test

1. Place `.env` in backend root
2. Run `uvicorn app.main:app --reload` from any folder
3. Verify that environment variables load correctly
4. Remove `.env` and confirm the app exits with an error
