### PR TITLE
feat(root): add ASCII art welcome screen

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from routes.root import router as root_router
 from routes.test import router as test_router
 from routes.upload import router as upload_router
 from routes.chat import router as chat_router
@@ -15,14 +16,9 @@ setup_logging()
 # request id middleware
 register_request_id_middleware(app)
 
-@app.get("/")
-def root():
-    logger.info("Root endpoint accessed") # Log access to root endpoint
-    return {"message": "ChatVector AI Backend is Live!"} 
-
-app.include_router(test_router) 
+app.include_router(root_router)
+app.include_router(test_router)
 app.include_router(upload_router)
 app.include_router(chat_router)
 
 logger.info("Application startup complete.")
-

--- a/backend/routes/root.py
+++ b/backend/routes/root.py
@@ -1,0 +1,35 @@
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ASCII_ART = (
+    "   ________          __  _    __           __            ___    ____\n"
+    "  / ____/ /_  ____ _/ /_| |  / /__  ____  / /_____  ____/   |  /  _/\n"
+    " / /   / __ \\/ __ `/ __/| | / / _ \\/ __ \\/ __/ __ \\/ ___/ /| |  / /\n"
+    "/ /___/ / / / /_/ / /_  | |/ /  __/ / / / /_/ /_/ / /  / ___ |_/ /\n"
+    "\\____/_/ /_/\\__,_/\\__/  |___/\\___/_/ /_/\\__/\\____/_/  /_/  |_/___/\n"
+    "                                                                    \n"
+    "\n"
+    "ChatVector AI Backend is Live!\n"
+)
+
+
+def _is_browser(request: Request) -> bool:
+    # Prefer Accept header, then fall back to User-Agent heuristics.
+    accept = request.headers.get("accept", "").lower()
+    if "text/html" in accept:
+        return True
+    user_agent = request.headers.get("user-agent", "").lower()
+    return any(token in user_agent for token in ("mozilla", "chrome", "safari", "firefox", "edge"))
+
+
+@router.get("/")
+def root(request: Request):
+    logger.info("Root endpoint accessed")
+    if _is_browser(request):
+        return HTMLResponse(content=f"<pre style=\"font-family: monospace;\">{ASCII_ART}</pre>")
+    return {"message": "ChatVector AI Backend is Live!"}


### PR DESCRIPTION
## Summary
- Moved the root endpoint into a dedicated router at `backend/routes/root.py`
- Added browser detection using `Accept` and `User-Agent`
- Returns an HTML ASCII banner for browser requests
- Keeps the original JSON response for API clients
- Included the new root router in `backend/main.py`

## Verification
- Browser-style request returns `text/html` with the ASCII banner
- API-style request returns the original JSON message

Closes #56

@admaloch please review.