### PR TITLE
docs: add MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,4 +295,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## 📄 License
 
-MIT License
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://choosealicense.com/licenses/mit/)
+


### PR DESCRIPTION
Closes #65 
Added standard MIT license badge using shields.io.
@admaloch 