### PR TITLE
Fix MIT license badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,4 +304,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## 📄 License
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://choosealicense.com/licenses/mit/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/chatvector-ai/chatvector-ai/blob/main/LICENSE)


### PR DESCRIPTION
## Summary

The MIT license badge at the bottom of the README.md currently links to an example page instead of the actual license file in this repository.

This PR updates the badge link to point to the actual LICENSE file.

Closes #80