### PR TITLE
docs: add MAX_UPLOAD_SIZE_MB to env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ LOG_LEVEL=INFO
 LOG_USE_UTC=false
 GEN_AI_KEY=your_google_ai_studio_api_key_here
 # Replace GEN_AI_KEY with your actual API key
+
+# Upload validation
+MAX_UPLOAD_SIZE_MB=10
 ```
 
 ### Launch Backend


### PR DESCRIPTION
Closes #102

## Changes
 Added `MAX_UPLOAD_SIZE_MB=10` to the Setup `.env` section in README.md
 Added blank line for consistent spacing with existing style

## Why
The README was missing the upload validation variable, making it unclear to new contributors that this environment variable is required.