### PR TITLE
feat(chat): harden async batch retrieval and add SQLAlchemy parity improvements

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -36,6 +36,10 @@ class Settings:
     SUPABASE_IO_CONCURRENCY: int = max(1, int(os.getenv("SUPABASE_IO_CONCURRENCY", "16")))
     CHAT_BATCH_MAX_ITEMS: int = max(1, int(os.getenv("CHAT_BATCH_MAX_ITEMS", "20")))
     CHAT_MAX_DOC_IDS_PER_QUERY: int = max(1, int(os.getenv("CHAT_MAX_DOC_IDS_PER_QUERY", "10")))
+    SQLALCHEMY_POOL_SIZE: int = max(1, int(os.getenv("SQLALCHEMY_POOL_SIZE", "5")))
+    SQLALCHEMY_MAX_OVERFLOW: int = max(0, int(os.getenv("SQLALCHEMY_MAX_OVERFLOW", "10")))
+    SQLALCHEMY_POOL_TIMEOUT_SEC: int = max(1, int(os.getenv("SQLALCHEMY_POOL_TIMEOUT_SEC", "30")))
+    SQLALCHEMY_RETRIEVAL_CONCURRENCY: int = max(1, int(os.getenv("SQLALCHEMY_RETRIEVAL_CONCURRENCY", "8")))
 
     # Backwards-compatible lowercase properties for accessing config values
     @property

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -49,8 +49,13 @@ async def chat_batch(payload: ChatBatchRequest):
             },
         )
 
+    success_count = sum(1 for item in results if item.get("status") == "ok")
+    failure_count = len(results) - success_count
+
     return {
         "count": len(results),
+        "success_count": success_count,
+        "failure_count": failure_count,
         "results": results,
     }
 

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -7,6 +7,20 @@ from services.context_service import build_context_from_chunks
 
 logger = logging.getLogger(__name__)
 
+_retrieval_limit = max(1, int(config.RETRIEVAL_MAX_CONCURRENCY))
+_retrieval_semaphore = asyncio.Semaphore(_retrieval_limit)
+
+
+def _get_retrieval_semaphore() -> asyncio.Semaphore:
+    global _retrieval_limit, _retrieval_semaphore
+
+    configured_limit = max(1, int(config.RETRIEVAL_MAX_CONCURRENCY))
+    if configured_limit != _retrieval_limit:
+        _retrieval_limit = configured_limit
+        _retrieval_semaphore = asyncio.Semaphore(_retrieval_limit)
+
+    return _retrieval_semaphore
+
 
 async def get_embedding(text: str) -> list[float]:
     """
@@ -35,16 +49,34 @@ async def get_embeddings(texts: list[str]) -> list[list[float]]:
     return await _get_embeddings(texts)
 
 
-def _normalize_doc_ids(doc_ids: list[str]) -> list[str]:
-    seen = set()
+def _normalize_doc_ids(doc_ids: list[str], *, query_index: int) -> list[str]:
+    seen: set[str] = set()
     normalized: list[str] = []
+    empty_positions: list[int] = []
+    duplicate_ids: list[str] = []
 
-    for raw_doc_id in doc_ids:
+    for position, raw_doc_id in enumerate(doc_ids, start=1):
         doc_id = (raw_doc_id or "").strip()
-        if not doc_id or doc_id in seen:
+        if not doc_id:
+            empty_positions.append(position)
             continue
+        if doc_id in seen:
+            duplicate_ids.append(doc_id)
+            continue
+
         seen.add(doc_id)
         normalized.append(doc_id)
+
+    if empty_positions:
+        raise ValueError(
+            f"Query #{query_index} contains empty document IDs at positions {empty_positions}"
+        )
+
+    if duplicate_ids:
+        duplicate_values = sorted(set(duplicate_ids))
+        raise ValueError(
+            f"Query #{query_index} contains duplicate doc IDs: {duplicate_values}"
+        )
 
     return normalized
 
@@ -53,8 +85,9 @@ async def _retrieve_chunks_for_documents(
     doc_ids: list[str],
     query_embedding: list[float],
     match_count: int,
-    retrieval_semaphore: asyncio.Semaphore,
 ) -> list:
+    retrieval_semaphore = _get_retrieval_semaphore()
+
     async def _search_one_document(doc_id: str) -> list:
         async with retrieval_semaphore:
             return await find_similar_chunks(
@@ -85,12 +118,10 @@ async def answer_question_for_document(
     logger.info(f"Starting chat for document {doc_id}")
 
     query_embedding = await get_embedding(question)
-    retrieval_semaphore = asyncio.Semaphore(config.RETRIEVAL_MAX_CONCURRENCY)
     matching_chunks = await _retrieve_chunks_for_documents(
         doc_ids=[doc_id],
         query_embedding=query_embedding,
         match_count=match_count,
-        retrieval_semaphore=retrieval_semaphore,
     )
     context = build_context_from_chunks(matching_chunks)
     answer = await generate_answer(question, context)
@@ -123,7 +154,7 @@ async def answer_questions_for_documents_batch(
         if not question:
             raise ValueError(f"Query #{index} has empty question")
 
-        doc_ids = _normalize_doc_ids(query.get("doc_ids") or [])
+        doc_ids = _normalize_doc_ids(query.get("doc_ids") or [], query_index=index)
         if not doc_ids:
             raise ValueError(f"Query #{index} has no valid document IDs")
 
@@ -146,28 +177,57 @@ async def answer_questions_for_documents_batch(
 
     embeddings = await get_embeddings([q["question"] for q in normalized_queries])
     if len(embeddings) != len(normalized_queries):
-        raise RuntimeError(
+        mismatch_message = (
             f"Embedding mismatch: got {len(embeddings)} embeddings for {len(normalized_queries)} queries"
         )
-
-    retrieval_semaphore = asyncio.Semaphore(config.RETRIEVAL_MAX_CONCURRENCY)
+        logger.error(mismatch_message)
+        return [
+            {
+                "status": "error",
+                "question": query["question"],
+                "doc_ids": query["doc_ids"],
+                "chunks": 0,
+                "error": {
+                    "code": "embedding_mismatch",
+                    "message": mismatch_message,
+                },
+            }
+            for query in normalized_queries
+        ]
 
     async def _process_query(query: dict, query_embedding: list[float]) -> dict:
-        matching_chunks = await _retrieve_chunks_for_documents(
-            doc_ids=query["doc_ids"],
-            query_embedding=query_embedding,
-            match_count=query["match_count"],
-            retrieval_semaphore=retrieval_semaphore,
-        )
-        context = build_context_from_chunks(matching_chunks)
-        answer = await generate_answer(query["question"], context)
+        try:
+            matching_chunks = await _retrieve_chunks_for_documents(
+                doc_ids=query["doc_ids"],
+                query_embedding=query_embedding,
+                match_count=query["match_count"],
+            )
+            context = build_context_from_chunks(matching_chunks)
+            answer = await generate_answer(query["question"], context)
 
-        return {
-            "question": query["question"],
-            "doc_ids": query["doc_ids"],
-            "chunks": len(matching_chunks),
-            "answer": answer,
-        }
+            return {
+                "status": "ok",
+                "question": query["question"],
+                "doc_ids": query["doc_ids"],
+                "chunks": len(matching_chunks),
+                "answer": answer,
+            }
+        except Exception as e:
+            logger.exception(
+                "Batch query failed for question='%s' doc_ids=%s",
+                query["question"],
+                query["doc_ids"],
+            )
+            return {
+                "status": "error",
+                "question": query["question"],
+                "doc_ids": query["doc_ids"],
+                "chunks": 0,
+                "error": {
+                    "code": "query_processing_failed",
+                    "message": str(e),
+                },
+            }
 
     return await asyncio.gather(
         *[

--- a/backend/tests/test_sqlalchemy_retrieval.py
+++ b/backend/tests/test_sqlalchemy_retrieval.py
@@ -1,0 +1,85 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("pgvector")
+
+from db.sqlalchemy_service import SQLAlchemyService
+
+
+class _FakeChunk:
+    def __init__(self, chunk_id: str, doc_id: str):
+        self.id = chunk_id
+        self.chunk_text = "chunk"
+        self.document_id = doc_id
+        self.embedding = [0.1, 0.2]
+        self.created_at = datetime.utcnow()
+
+
+class _FakeResult:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._chunks
+
+
+class _FakeSession:
+    def __init__(self, on_execute):
+        self._on_execute = on_execute
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, *args, **kwargs):
+        return await self._on_execute()
+
+
+@pytest.mark.asyncio
+async def test_find_similar_chunks_respects_service_retrieval_limit():
+    service = SQLAlchemyService()
+    service._retrieval_semaphore = asyncio.Semaphore(1)
+
+    active_calls = 0
+    max_active_calls = 0
+
+    async def on_execute():
+        nonlocal active_calls, max_active_calls
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        await asyncio.sleep(0.01)
+        active_calls -= 1
+        return _FakeResult([_FakeChunk("chunk-1", "doc-1")])
+
+    service.async_session = lambda: _FakeSession(on_execute)
+
+    await asyncio.gather(
+        service.find_similar_chunks("doc-1", [0.1, 0.2], 1),
+        service.find_similar_chunks("doc-1", [0.1, 0.2], 1),
+    )
+
+    assert max_active_calls <= 1
+
+
+@pytest.mark.asyncio
+async def test_find_similar_chunks_logs_errors():
+    service = SQLAlchemyService()
+
+    async def on_execute():
+        raise RuntimeError("db error")
+
+    service.async_session = lambda: _FakeSession(on_execute)
+
+    with patch("db.sqlalchemy_service.logger.exception") as mock_log:
+        with pytest.raises(RuntimeError, match="db error"):
+            await service.find_similar_chunks("doc-1", [0.1, 0.2], 1)
+
+    mock_log.assert_called_once()


### PR DESCRIPTION

## Summary
This PR hardens chat retrieval behavior for multi-query/multi-document use cases and aligns key reliability/performance controls across both DB adapters (Supabase + SQLAlchemy).

It builds on the previous async/batch retrieval work by improving concurrency control, batch failure handling, observability, and adapter parity.

-closes #107

## Why
The initial async/batch implementation worked functionally, but had follow-up gaps:
- retrieval throttling scope was request-local
- batch behavior was all-or-nothing
- I/O observability in Supabase wrapper needed improvement
- SQLAlchemy path needed equivalent tuning and retrieval protections

## What Changed
### Chat Service Hardening
- `backend/services/chat_service.py`
  - Added process-level retrieval limiter (`_get_retrieval_semaphore`) instead of per-request semaphore creation.
  - Added stricter `doc_ids` normalization/validation:
    - reject empty IDs (with positional detail)
    - reject duplicates (explicit error)
  - Added partial-failure batch semantics:
    - each result now has `status: "ok" | "error"`
    - per-item failures return `error` payload instead of failing the entire batch
  - Added explicit embedding mismatch fallback result payloads instead of raising global runtime failure.

### Route Response Improvements
- `backend/routes/chat.py`
  - Batch response now includes:
    - `count`
    - `success_count`
    - `failure_count`
    - `results`

### Supabase I/O Hardening
- `backend/db/supabase_service.py`
  - Replaced implicit `to_thread` usage with explicit executor path via `run_in_executor`.
  - Added dedicated thread pool management for Supabase operations.
  - Added operation-level error logging in `_run_io(..., operation_name=...)`.
  - Updated all Supabase DB calls to pass operation names for observability.

### SQLAlchemy Parity Updates
- `backend/core/config.py`
  - Added SQLAlchemy tuning knobs:
    - `SQLALCHEMY_POOL_SIZE`
    - `SQLALCHEMY_MAX_OVERFLOW`
    - `SQLALCHEMY_POOL_TIMEOUT_SEC`
    - `SQLALCHEMY_RETRIEVAL_CONCURRENCY`
- `backend/db/sqlalchemy_service.py`
  - Switched pool settings to config-driven values.
  - Added retrieval semaphore to bound concurrent vector retrieval operations.
  - Added retrieval timing + exception logging for better diagnostics.

### Tests
- Updated `backend/tests/test_chat_service.py`
  - verifies `status`-based batch results
  - verifies partial failures do not fail whole batch
  - verifies duplicate `doc_ids` are rejected
- Updated `backend/tests/test_chat_route.py`
  - verifies `success_count` / `failure_count`
- Updated `backend/tests/test_supabase_async.py`
  - verifies `run_in_executor` path
  - verifies error logging on I/O wrapper failure
- Added `backend/tests/test_sqlalchemy_retrieval.py`
  - verifies retrieval semaphore limiting
  - verifies SQLAlchemy retrieval error logging behavior

## Behavior / Contract Notes
- `/chat` single request behavior remains compatible.
- `/chat/batch` response shape is expanded with per-item status semantics and aggregate success/failure counts.
- Invalid batch input still returns `422` from route-level `ValueError` mapping.

## Test Evidence
Ran in Docker:
- `docker compose run --rm tests pytest -q tests/test_chat_service.py tests/test_chat_route.py tests/test_supabase_async.py tests/test_sqlalchemy_retrieval.py`
- `docker compose run --rm tests pytest -q`

Both passed.

## Risks / Follow-ups
- Retrieval semaphore is process-scoped (per worker), not cluster-global.
- Batch error payload format should be documented for API consumers if external clients rely on strict schemas.

## Checklist
- [x] Process-level retrieval throttling for chat retrieval
- [x] Partial failure semantics for batch processing
- [x] Supabase I/O observability improvements
- [x] SQLAlchemy parity and tuning controls
- [x] Tests updated/added for all above changes
- [x] Full backend test suite passing
