### PR TITLE
refactor(upload): move upload orchestration into IngestionPipeline service

### DIFF
--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -1,27 +1,11 @@
 import logging
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-
-import db
-from core.config import config
-from services.embedding_service import get_embeddings
-from services.extraction_service import extract_text_from_file
+from services.ingestion_pipeline import IngestionPipeline, UploadPipelineError
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-ALLOWED_UPLOAD_TYPES = {"application/pdf", "text/plain"}
-
-
-class UploadPipelineError(Exception):
-    def __init__(self, status_code: int, code: str, stage: str, message: str):
-        super().__init__(message)
-        self.status_code = status_code
-        self.code = code
-        self.stage = stage
-        self.message = message
-
+ingestion_pipeline = IngestionPipeline()
 
 def _http_error(
     status_code: int,
@@ -39,154 +23,16 @@ def _http_error(
         detail["document_id"] = document_id
     return HTTPException(status_code=status_code, detail=detail)
 
-
-async def _mark_failed_upload(doc_id: str, stage: str, message: str) -> None:
-    """Best-effort status update + chunk cleanup for failed uploads."""
-    safe_message = message[:500]
-    try:
-        await db.update_document_status(
-            doc_id=doc_id,
-            status="failed",
-            failed_stage=stage,
-            error_message=safe_message,
-        )
-    except Exception as status_error:
-        logger.error(f"Failed to mark document {doc_id} as failed: {status_error}")
-
-    try:
-        await db.delete_document_chunks(doc_id)
-    except Exception as cleanup_error:
-        logger.error(f"Failed to cleanup chunks for document {doc_id}: {cleanup_error}")
-
-
 @router.post("/upload")
 async def upload(file: UploadFile = File(...)):
-    logger.info(f"Starting upload for file: {file.filename} ({file.content_type})")
-
-    doc_id: str | None = None
-    stage = "validation"
-
     try:
-        if file.content_type not in ALLOWED_UPLOAD_TYPES:
-            raise UploadPipelineError(
-                status_code=400,
-                code="invalid_file_type",
-                stage=stage,
-                message="Only PDF and TXT files are supported.",
-            )
-
-        file_bytes = await file.read()
-
-        if not file_bytes:
-            raise UploadPipelineError(
-                status_code=400,
-                code="empty_file",
-                stage=stage,
-                message="Uploaded file is empty.",
-            )
-
-        if len(file_bytes) > config.MAX_UPLOAD_SIZE_BYTES:
-            raise UploadPipelineError(
-                status_code=413,
-                code="file_too_large",
-                stage=stage,
-                message=(
-                    f"File exceeds maximum upload size of {config.MAX_UPLOAD_SIZE_MB} MB."
-                ),
-            )
-
-        # Create document only after pre-validation passes
-        stage = "uploaded"
-        doc_id = await db.create_document(file.filename)
-        await db.update_document_status(doc_id=doc_id, status="uploaded")
-
-        stage = "extracting"
-        await db.update_document_status(doc_id=doc_id, status="extracting")
-        file_text = await extract_text_from_file(file, file_bytes)
-
-        if not file_text.strip():
-            raise UploadPipelineError(
-                status_code=422,
-                code="no_text_extracted",
-                stage=stage,
-                message="No extractable text was found in the uploaded document.",
-            )
-
-        stage = "chunking"
-        await db.update_document_status(doc_id=doc_id, status="chunking")
-        splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
-        chunks = splitter.split_text(file_text)
-
-        if not chunks:
-            raise UploadPipelineError(
-                status_code=422,
-                code="no_chunks_generated",
-                stage=stage,
-                message="No chunks were generated from extracted text.",
-            )
-
-        stage = "embedding"
-        await db.update_document_status(
-            doc_id=doc_id,
-            status="embedding",
-            chunks_total=len(chunks),
-            chunks_processed=0,
-        )
-        embeddings = await get_embeddings(chunks)
-
-        if len(embeddings) != len(chunks):
-            raise UploadPipelineError(
-                status_code=500,
-                code="embedding_mismatch",
-                stage=stage,
-                message="Embedding generation returned an unexpected number of vectors.",
-            )
-
-        stage = "storing"
-        await db.update_document_status(doc_id=doc_id, status="storing")
-        chunk_ids = await db.store_chunks_with_embeddings(doc_id, list(zip(chunks, embeddings)))
-
-        await db.update_document_status(
-            doc_id=doc_id,
-            status="completed",
-            failed_stage="",
-            error_message="",
-            chunks_total=len(chunks),
-            chunks_processed=len(chunk_ids),
-        )
-
-        logger.info(
-            f"Successfully uploaded {len(chunk_ids)} chunks for document {doc_id}"
-        )
-
-        return {
-            "message": "Uploaded",
-            "document_id": doc_id,
-            "chunks": len(chunk_ids),
-            "status": "completed",
-            "status_endpoint": f"/documents/{doc_id}/status",
-        }
+        return await ingestion_pipeline.process_document(file)
 
     except UploadPipelineError as e:
-        if doc_id:
-            await _mark_failed_upload(doc_id=doc_id, stage=e.stage, message=e.message)
-        logger.warning(f"Upload validation/pipeline failed at stage={e.stage}: {e.message}")
         raise _http_error(
             status_code=e.status_code,
             code=e.code,
             stage=e.stage,
             message=e.message,
-            document_id=doc_id,
-        )
-
-    except Exception as e:
-        if doc_id:
-            await _mark_failed_upload(doc_id=doc_id, stage=stage, message=str(e))
-        logger.error(f"Upload failed at stage={stage} for file {file.filename}: {e}")
-        raise _http_error(
-            status_code=500,
-            code="upload_failed",
-            stage=stage,
-            message="Upload failed. Please try again.",
-            document_id=doc_id,
+            document_id=getattr(e, "document_id", None),
         )

--- a/backend/services/ingestion_pipeline.py
+++ b/backend/services/ingestion_pipeline.py
@@ -1,0 +1,208 @@
+import logging
+
+from fastapi import UploadFile
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+import db
+from core.config import config
+from services.embedding_service import get_embeddings
+from services.extraction_service import extract_text_from_file
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_UPLOAD_TYPES = {"application/pdf", "text/plain"}
+
+
+class UploadPipelineError(Exception):
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        stage: str,
+        message: str,
+        document_id: str | None = None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.stage = stage
+        self.message = message
+        self.document_id = document_id
+
+
+class IngestionPipeline:
+    def __init__(self, splitter_cls=None):
+        self._splitter_cls = splitter_cls or RecursiveCharacterTextSplitter
+
+    def validate_file(self, file: UploadFile, file_bytes: bytes) -> None:
+        stage = "validation"
+
+        if file.content_type not in ALLOWED_UPLOAD_TYPES:
+            raise UploadPipelineError(
+                status_code=400,
+                code="invalid_file_type",
+                stage=stage,
+                message="Only PDF and TXT files are supported.",
+            )
+
+        if not file_bytes:
+            raise UploadPipelineError(
+                status_code=400,
+                code="empty_file",
+                stage=stage,
+                message="Uploaded file is empty.",
+            )
+
+        if len(file_bytes) > config.MAX_UPLOAD_SIZE_BYTES:
+            raise UploadPipelineError(
+                status_code=413,
+                code="file_too_large",
+                stage=stage,
+                message=(
+                    f"File exceeds maximum upload size of {config.MAX_UPLOAD_SIZE_MB} MB."
+                ),
+            )
+
+    async def _update_status(
+        self,
+        doc_id: str,
+        status: str,
+        failed_stage: str | None = None,
+        error_message: str | None = None,
+        chunks_total: int | None = None,
+        chunks_processed: int | None = None,
+    ) -> None:
+        await db.update_document_status(
+            doc_id=doc_id,
+            status=status,
+            failed_stage=failed_stage,
+            error_message=error_message,
+            chunks_total=chunks_total,
+            chunks_processed=chunks_processed,
+        )
+
+    async def _handle_error(self, doc_id: str, stage: str, message: str) -> None:
+        safe_message = message[:500]
+        try:
+            await self._update_status(
+                doc_id=doc_id,
+                status="failed",
+                failed_stage=stage,
+                error_message=safe_message,
+            )
+        except Exception as status_error:
+            logger.error(f"Failed to mark document {doc_id} as failed: {status_error}")
+
+        try:
+            await db.delete_document_chunks(doc_id)
+        except Exception as cleanup_error:
+            logger.error(f"Failed to cleanup chunks for document {doc_id}: {cleanup_error}")
+
+    async def process_document(self, file: UploadFile) -> dict:
+        logger.info(f"Starting upload for file: {file.filename} ({file.content_type})")
+
+        doc_id: str | None = None
+        stage = "validation"
+
+        try:
+            file_bytes = await file.read()
+            self.validate_file(file, file_bytes)
+
+            stage = "uploaded"
+            doc_id = await db.create_document(file.filename)
+            await self._update_status(doc_id=doc_id, status="uploaded")
+
+            stage = "extracting"
+            await self._update_status(doc_id=doc_id, status="extracting")
+            file_text = await extract_text_from_file(file, file_bytes)
+
+            if not file_text.strip():
+                raise UploadPipelineError(
+                    status_code=422,
+                    code="no_text_extracted",
+                    stage=stage,
+                    message="No extractable text was found in the uploaded document.",
+                )
+
+            stage = "chunking"
+            await self._update_status(doc_id=doc_id, status="chunking")
+            splitter = self._splitter_cls(chunk_size=1000, chunk_overlap=200)
+            chunks = splitter.split_text(file_text)
+
+            if not chunks:
+                raise UploadPipelineError(
+                    status_code=422,
+                    code="no_chunks_generated",
+                    stage=stage,
+                    message="No chunks were generated from extracted text.",
+                )
+
+            stage = "embedding"
+            await self._update_status(
+                doc_id=doc_id,
+                status="embedding",
+                chunks_total=len(chunks),
+                chunks_processed=0,
+            )
+            embeddings = await get_embeddings(chunks)
+
+            if len(embeddings) != len(chunks):
+                raise UploadPipelineError(
+                    status_code=500,
+                    code="embedding_mismatch",
+                    stage=stage,
+                    message="Embedding generation returned an unexpected number of vectors.",
+                )
+
+            stage = "storing"
+            await self._update_status(doc_id=doc_id, status="storing")
+            chunk_ids = await db.store_chunks_with_embeddings(
+                doc_id,
+                list(zip(chunks, embeddings)),
+            )
+
+            await self._update_status(
+                doc_id=doc_id,
+                status="completed",
+                failed_stage="",
+                error_message="",
+                chunks_total=len(chunks),
+                chunks_processed=len(chunk_ids),
+            )
+
+            logger.info(
+                f"Successfully uploaded {len(chunk_ids)} chunks for document {doc_id}"
+            )
+
+            return {
+                "message": "Uploaded",
+                "document_id": doc_id,
+                "chunks": len(chunk_ids),
+                "status": "completed",
+                "status_endpoint": f"/documents/{doc_id}/status",
+            }
+
+        except UploadPipelineError as e:
+            if doc_id and not e.document_id:
+                e.document_id = doc_id
+
+            if doc_id:
+                await self._handle_error(doc_id=doc_id, stage=e.stage, message=e.message)
+
+            logger.warning(
+                f"Upload validation/pipeline failed at stage={e.stage}: {e.message}"
+            )
+            raise
+
+        except Exception as e:
+            if doc_id:
+                await self._handle_error(doc_id=doc_id, stage=stage, message=str(e))
+
+            logger.error(f"Upload failed at stage={stage} for file {file.filename}: {e}")
+            raise UploadPipelineError(
+                status_code=500,
+                code="upload_failed",
+                stage=stage,
+                message="Upload failed. Please try again.",
+                document_id=doc_id,
+            )

--- a/backend/tests/test_ingestion_pipeline.py
+++ b/backend/tests/test_ingestion_pipeline.py
@@ -1,0 +1,166 @@
+"""Ingestion pipeline tests for validation, status tracking, and failure handling."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import UploadFile
+
+from services.ingestion_pipeline import IngestionPipeline, UploadPipelineError
+
+
+class _FixedSplitter:
+    def __init__(self, chunk_size: int, chunk_overlap: int):
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    def split_text(self, text: str) -> list[str]:
+        return ["chunk-a", "chunk-b"]
+
+
+class _SingleChunkSplitter:
+    def __init__(self, chunk_size: int, chunk_overlap: int):
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    def split_text(self, text: str) -> list[str]:
+        return ["chunk-a"]
+
+
+@pytest.mark.asyncio
+async def test_process_document_success_tracks_status_and_returns_status_endpoint(monkeypatch):
+    mock_file = AsyncMock(spec=UploadFile)
+    mock_file.filename = "test.pdf"
+    mock_file.content_type = "application/pdf"
+    mock_file.read = AsyncMock(return_value=b"fake-pdf-bytes")
+
+    monkeypatch.setattr("services.ingestion_pipeline.config.MAX_UPLOAD_SIZE_BYTES", 10 * 1024 * 1024)
+    monkeypatch.setattr("services.ingestion_pipeline.config.MAX_UPLOAD_SIZE_MB", 10)
+
+    pipeline = IngestionPipeline(splitter_cls=_FixedSplitter)
+
+    with patch("services.ingestion_pipeline.db.create_document", new=AsyncMock(return_value="doc123")) as mock_create, patch(
+        "services.ingestion_pipeline.db.update_document_status", new=AsyncMock()
+    ) as mock_update, patch(
+        "services.ingestion_pipeline.db.store_chunks_with_embeddings", new=AsyncMock(return_value=["c1", "c2"])
+    ) as mock_store, patch(
+        "services.ingestion_pipeline.db.delete_document_chunks", new=AsyncMock()
+    ) as mock_cleanup, patch(
+        "services.ingestion_pipeline.extract_text_from_file", new=AsyncMock(return_value="hello world")
+    ) as mock_extract, patch(
+        "services.ingestion_pipeline.get_embeddings", new=AsyncMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
+    ):
+        result = await pipeline.process_document(mock_file)
+
+    assert result["document_id"] == "doc123"
+    assert result["chunks"] == 2
+    assert result["status"] == "completed"
+    assert result["status_endpoint"] == "/documents/doc123/status"
+
+    mock_create.assert_awaited_once()
+    mock_extract.assert_awaited_once()
+    mock_store.assert_awaited_once()
+    mock_cleanup.assert_not_awaited()
+
+    statuses = [call.kwargs.get("status") for call in mock_update.await_args_list]
+    assert statuses == ["uploaded", "extracting", "chunking", "embedding", "storing", "completed"]
+
+
+@pytest.mark.asyncio
+async def test_process_document_rejects_invalid_file_type():
+    mock_file = AsyncMock(spec=UploadFile)
+    mock_file.filename = "bad.docx"
+    mock_file.content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    mock_file.read = AsyncMock(return_value=b"x")
+
+    pipeline = IngestionPipeline(splitter_cls=_SingleChunkSplitter)
+
+    with pytest.raises(UploadPipelineError) as excinfo:
+        await pipeline.process_document(mock_file)
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.code == "invalid_file_type"
+    assert excinfo.value.stage == "validation"
+
+
+@pytest.mark.asyncio
+async def test_process_document_rejects_file_too_large(monkeypatch):
+    mock_file = AsyncMock(spec=UploadFile)
+    mock_file.filename = "large.pdf"
+    mock_file.content_type = "application/pdf"
+    mock_file.read = AsyncMock(return_value=b"x" * 20)
+
+    monkeypatch.setattr("services.ingestion_pipeline.config.MAX_UPLOAD_SIZE_BYTES", 5)
+    monkeypatch.setattr("services.ingestion_pipeline.config.MAX_UPLOAD_SIZE_MB", 0)
+
+    pipeline = IngestionPipeline()
+
+    with pytest.raises(UploadPipelineError) as excinfo:
+        await pipeline.process_document(mock_file)
+
+    assert excinfo.value.status_code == 413
+    assert excinfo.value.code == "file_too_large"
+    assert excinfo.value.stage == "validation"
+
+
+@pytest.mark.asyncio
+async def test_process_document_marks_failed_when_no_text_extracted(monkeypatch):
+    mock_file = AsyncMock(spec=UploadFile)
+    mock_file.filename = "empty.pdf"
+    mock_file.content_type = "application/pdf"
+    mock_file.read = AsyncMock(return_value=b"fake-pdf-bytes")
+
+    monkeypatch.setattr("services.ingestion_pipeline.config.MAX_UPLOAD_SIZE_BYTES", 10 * 1024 * 1024)
+
+    pipeline = IngestionPipeline()
+
+    with patch("services.ingestion_pipeline.db.create_document", new=AsyncMock(return_value="doc-no-text")), patch(
+        "services.ingestion_pipeline.db.update_document_status", new=AsyncMock()
+    ) as mock_update, patch(
+        "services.ingestion_pipeline.db.delete_document_chunks", new=AsyncMock()
+    ) as mock_cleanup, patch(
+        "services.ingestion_pipeline.extract_text_from_file", new=AsyncMock(return_value="   ")
+    ):
+        with pytest.raises(UploadPipelineError) as excinfo:
+            await pipeline.process_document(mock_file)
+
+    assert excinfo.value.status_code == 422
+    assert excinfo.value.code == "no_text_extracted"
+    assert excinfo.value.document_id == "doc-no-text"
+
+    mock_cleanup.assert_awaited_once_with("doc-no-text")
+    assert mock_update.await_args_list[-1].kwargs["status"] == "failed"
+    assert mock_update.await_args_list[-1].kwargs["failed_stage"] == "extracting"
+
+
+@pytest.mark.asyncio
+async def test_process_document_marks_failed_on_storage_error(monkeypatch):
+    mock_file = AsyncMock(spec=UploadFile)
+    mock_file.filename = "store-fail.pdf"
+    mock_file.content_type = "application/pdf"
+    mock_file.read = AsyncMock(return_value=b"fake-pdf-bytes")
+
+    monkeypatch.setattr("services.ingestion_pipeline.config.MAX_UPLOAD_SIZE_BYTES", 10 * 1024 * 1024)
+
+    pipeline = IngestionPipeline()
+
+    with patch("services.ingestion_pipeline.db.create_document", new=AsyncMock(return_value="doc-store-fail")), patch(
+        "services.ingestion_pipeline.db.update_document_status", new=AsyncMock()
+    ) as mock_update, patch(
+        "services.ingestion_pipeline.db.delete_document_chunks", new=AsyncMock()
+    ) as mock_cleanup, patch(
+        "services.ingestion_pipeline.extract_text_from_file", new=AsyncMock(return_value="hello world")), patch(
+        "services.ingestion_pipeline.get_embeddings", new=AsyncMock(return_value=[[0.1, 0.2]])
+    ), patch(
+        "services.ingestion_pipeline.db.store_chunks_with_embeddings", new=AsyncMock(side_effect=RuntimeError("db down"))
+    ):
+        with pytest.raises(UploadPipelineError) as excinfo:
+            await pipeline.process_document(mock_file)
+
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.code == "upload_failed"
+    assert excinfo.value.stage == "storing"
+    assert excinfo.value.document_id == "doc-store-fail"
+
+    mock_cleanup.assert_awaited_once_with("doc-store-fail")
+    assert mock_update.await_args_list[-1].kwargs["status"] == "failed"
+    assert mock_update.await_args_list[-1].kwargs["failed_stage"] == "storing"

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -1,145 +1,53 @@
-"""Upload route tests for validation, status tracking, and failure handling."""
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException, UploadFile
-from unittest.mock import AsyncMock, patch
 
 from routes.upload import upload
+from services.ingestion_pipeline import UploadPipelineError
 
 
 @pytest.mark.asyncio
-async def test_upload_success_tracks_status_and_returns_status_endpoint(monkeypatch):
+async def test_upload_route_delegates_to_ingestion_pipeline():
     mock_file = AsyncMock(spec=UploadFile)
-    mock_file.filename = "test.pdf"
-    mock_file.content_type = "application/pdf"
-    mock_file.read = AsyncMock(return_value=b"fake-pdf-bytes")
+    payload = {
+        "message": "Uploaded",
+        "document_id": "doc-1",
+        "chunks": 2,
+        "status": "completed",
+        "status_endpoint": "/documents/doc-1/status",
+    }
 
-    monkeypatch.setattr("routes.upload.config.MAX_UPLOAD_SIZE_BYTES", 10 * 1024 * 1024)
-    monkeypatch.setattr("routes.upload.config.MAX_UPLOAD_SIZE_MB", 10)
+    with patch(
+        "routes.upload.ingestion_pipeline.process_document",
+        new=AsyncMock(return_value=payload),
+    ) as mock_process:
+        result = await upload(mock_file)
 
-    with patch("routes.upload.db.create_document", new=AsyncMock(return_value="doc123")) as mock_create, patch(
-        "routes.upload.db.update_document_status", new=AsyncMock()
-    ) as mock_update, patch(
-        "routes.upload.db.store_chunks_with_embeddings", new=AsyncMock(return_value=["c1", "c2"])
-    ) as mock_store, patch(
-        "routes.upload.db.delete_document_chunks", new=AsyncMock()
-    ) as mock_cleanup, patch(
-        "routes.upload.extract_text_from_file", new=AsyncMock(return_value="hello world")
-    ) as mock_extract, patch(
-        "routes.upload.get_embeddings", new=AsyncMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
-    ):
-        with patch("routes.upload.RecursiveCharacterTextSplitter") as mock_splitter_cls:
-            mock_splitter = mock_splitter_cls.return_value
-            mock_splitter.split_text.return_value = ["chunk-a", "chunk-b"]
-
-            result = await upload(mock_file)
-
-    assert result["document_id"] == "doc123"
-    assert result["chunks"] == 2
-    assert result["status"] == "completed"
-    assert result["status_endpoint"] == "/documents/doc123/status"
-
-    mock_create.assert_awaited_once()
-    mock_extract.assert_awaited_once()
-    mock_store.assert_awaited_once()
-    mock_cleanup.assert_not_awaited()
-
-    statuses = [call.kwargs.get("status") for call in mock_update.await_args_list]
-    assert statuses == ["uploaded", "extracting", "chunking", "embedding", "storing", "completed"]
+    assert result == payload
+    mock_process.assert_awaited_once_with(mock_file)
 
 
 @pytest.mark.asyncio
-async def test_upload_rejects_invalid_file_type():
+async def test_upload_route_maps_pipeline_error_to_http_exception():
     mock_file = AsyncMock(spec=UploadFile)
-    mock_file.filename = "bad.docx"
-    mock_file.content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-    mock_file.read = AsyncMock(return_value=b"x")
 
-    with pytest.raises(HTTPException) as excinfo:
-        await upload(mock_file)
-
-    assert excinfo.value.status_code == 400
-    assert excinfo.value.detail["code"] == "invalid_file_type"
-    assert excinfo.value.detail["stage"] == "validation"
-
-
-@pytest.mark.asyncio
-async def test_upload_rejects_file_too_large(monkeypatch):
-    mock_file = AsyncMock(spec=UploadFile)
-    mock_file.filename = "large.pdf"
-    mock_file.content_type = "application/pdf"
-    mock_file.read = AsyncMock(return_value=b"x" * 20)
-
-    monkeypatch.setattr("routes.upload.config.MAX_UPLOAD_SIZE_BYTES", 5)
-    monkeypatch.setattr("routes.upload.config.MAX_UPLOAD_SIZE_MB", 0)
-
-    with pytest.raises(HTTPException) as excinfo:
-        await upload(mock_file)
-
-    assert excinfo.value.status_code == 413
-    assert excinfo.value.detail["code"] == "file_too_large"
-    assert excinfo.value.detail["stage"] == "validation"
-
-
-@pytest.mark.asyncio
-async def test_upload_marks_failed_when_no_text_extracted(monkeypatch):
-    mock_file = AsyncMock(spec=UploadFile)
-    mock_file.filename = "empty.pdf"
-    mock_file.content_type = "application/pdf"
-    mock_file.read = AsyncMock(return_value=b"fake-pdf-bytes")
-
-    monkeypatch.setattr("routes.upload.config.MAX_UPLOAD_SIZE_BYTES", 10 * 1024 * 1024)
-
-    with patch("routes.upload.db.create_document", new=AsyncMock(return_value="doc-no-text")), patch(
-        "routes.upload.db.update_document_status", new=AsyncMock()
-    ) as mock_update, patch(
-        "routes.upload.db.delete_document_chunks", new=AsyncMock()
-    ) as mock_cleanup, patch(
-        "routes.upload.extract_text_from_file", new=AsyncMock(return_value="   ")
+    with patch(
+        "routes.upload.ingestion_pipeline.process_document",
+        new=AsyncMock(
+            side_effect=UploadPipelineError(
+                status_code=422,
+                code="no_text_extracted",
+                stage="extracting",
+                message="No extractable text was found in the uploaded document.",
+                document_id="doc-err",
+            )
+        ),
     ):
         with pytest.raises(HTTPException) as excinfo:
             await upload(mock_file)
 
     assert excinfo.value.status_code == 422
     assert excinfo.value.detail["code"] == "no_text_extracted"
-    assert excinfo.value.detail["document_id"] == "doc-no-text"
-
-    mock_cleanup.assert_awaited_once_with("doc-no-text")
-    assert mock_update.await_args_list[-1].kwargs["status"] == "failed"
-    assert mock_update.await_args_list[-1].kwargs["failed_stage"] == "extracting"
-
-
-@pytest.mark.asyncio
-async def test_upload_marks_failed_on_storage_error(monkeypatch):
-    mock_file = AsyncMock(spec=UploadFile)
-    mock_file.filename = "store-fail.pdf"
-    mock_file.content_type = "application/pdf"
-    mock_file.read = AsyncMock(return_value=b"fake-pdf-bytes")
-
-    monkeypatch.setattr("routes.upload.config.MAX_UPLOAD_SIZE_BYTES", 10 * 1024 * 1024)
-
-    with patch("routes.upload.db.create_document", new=AsyncMock(return_value="doc-store-fail")), patch(
-        "routes.upload.db.update_document_status", new=AsyncMock()
-    ) as mock_update, patch(
-        "routes.upload.db.delete_document_chunks", new=AsyncMock()
-    ) as mock_cleanup, patch(
-        "routes.upload.extract_text_from_file", new=AsyncMock(return_value="hello world")), patch(
-        "routes.upload.get_embeddings", new=AsyncMock(return_value=[[0.1, 0.2]])
-    ), patch(
-        "routes.upload.db.store_chunks_with_embeddings", new=AsyncMock(side_effect=RuntimeError("db down"))
-    ):
-        with patch("routes.upload.RecursiveCharacterTextSplitter") as mock_splitter_cls:
-            mock_splitter = mock_splitter_cls.return_value
-            mock_splitter.split_text.return_value = ["chunk-a"]
-
-            with pytest.raises(HTTPException) as excinfo:
-                await upload(mock_file)
-
-    assert excinfo.value.status_code == 500
-    assert excinfo.value.detail["code"] == "upload_failed"
-    assert excinfo.value.detail["stage"] == "storing"
-    assert excinfo.value.detail["document_id"] == "doc-store-fail"
-
-    mock_cleanup.assert_awaited_once_with("doc-store-fail")
-    assert mock_update.await_args_list[-1].kwargs["status"] == "failed"
-    assert mock_update.await_args_list[-1].kwargs["failed_stage"] == "storing"
+    assert excinfo.value.detail["stage"] == "extracting"
+    assert excinfo.value.detail["document_id"] == "doc-err"


### PR DESCRIPTION
# PR Title
refactor(upload): move upload orchestration into `IngestionPipeline` service

-closes #74

# PR Body
## Summary
This PR refactors the upload flow by moving orchestration logic out of `routes/upload.py` and into a dedicated service:
- `services/ingestion_pipeline.py`

The route is now a thin HTTP adapter, while validation, stage transitions, extraction/chunking/embedding/storage orchestration, and cleanup logic are encapsulated in `IngestionPipeline`.

## Why
The upload endpoint had grown to handle too many responsibilities, making it harder to read, test, and maintain.

This change aligns upload architecture with the pattern used in other refactors (thin route + dedicated service orchestration).

## What Changed
### New
- `backend/services/ingestion_pipeline.py`
  - `UploadPipelineError` (structured pipeline error, supports `document_id`)
  - `IngestionPipeline.validate_file()`
  - `IngestionPipeline.process_document()`
  - `IngestionPipeline._update_status()`
  - `IngestionPipeline._handle_error()`

### Updated
- `backend/routes/upload.py`
  - now delegates to `ingestion_pipeline.process_document(file)`
  - maps `UploadPipelineError` to HTTP response payload
  - removed inline pipeline orchestration from route

### Tests
- Added `backend/tests/test_ingestion_pipeline.py`
  - success path
  - validation failures
  - no text extracted failure
  - storage failure path with failed status + cleanup checks
- Updated `backend/tests/test_upload.py`
  - route delegation test
  - route error-mapping test
- Existing `backend/tests/test_upload_atomic.py` remains passing

## Behavior / API Contract
- Upload success response shape is preserved:
  - `message`, `document_id`, `chunks`, `status`, `status_endpoint`
- Error response shape is preserved:
  - `code`, `stage`, `message`, and `document_id` when available

## Test Evidence
Ran in Docker:
- `docker compose run --rm tests pytest -q tests/test_upload.py tests/test_ingestion_pipeline.py tests/test_upload_atomic.py`
- `docker compose run --rm tests pytest -q`

Both passed.

## Notes
- This PR is focused on structural refactor only.
- No endpoint path changes and no ingestion algorithm changes were introduced.

## Checklist
- [x] Route simplified to thin adapter
- [x] Upload orchestration moved into dedicated service
- [x] Structured error handling retained
- [x] Upload-focused tests updated/added
- [x] Full backend test suite passing
