### PR TITLE
feat(ingestion): add text cleaning and normalization pipeline stage

### DIFF
--- a/backend/services/ingestion_pipeline.py
+++ b/backend/services/ingestion_pipeline.py
@@ -7,6 +7,7 @@ import db
 from core.config import config
 from services.embedding_service import get_embeddings
 from services.extraction_service import extract_text_from_file
+from services.text_cleaning_service import clean_text
 
 logger = logging.getLogger(__name__)
 
@@ -115,8 +116,9 @@ class IngestionPipeline:
             stage = "extracting"
             await self._update_status(doc_id=doc_id, status="extracting")
             file_text = await extract_text_from_file(file, file_bytes)
+            file_text = clean_text(file_text)
 
-            if not file_text.strip():
+            if not file_text:
                 raise UploadPipelineError(
                     status_code=422,
                     code="no_text_extracted",

--- a/backend/services/text_cleaning_service.py
+++ b/backend/services/text_cleaning_service.py
@@ -1,0 +1,42 @@
+"""
+Text cleaning and normalization for extracted document content.
+Applied between extraction and chunking to improve embedding quality
+and downstream RAG retrieval accuracy.
+"""
+
+import logging
+import re
+import unicodedata
+
+logger = logging.getLogger(__name__)
+
+
+def clean_text(text: str) -> str:
+   
+    if not text:
+        return text
+
+    original_len = len(text)
+
+    # 1. Unicode normalization
+    text = unicodedata.normalize("NFKC", text)
+    # 2. Remove non-printable control chars; keep \t (0x09), \n (0x0A), \r (0x0D)
+    text = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", text)
+    # 3. Remove soft hyphens
+    text = text.replace("\u00ad", "")
+    # 4. Rejoin hyphenated line breaks (PDF word-wrap artifact)
+    #    "connec-\ntion" → "connection"
+    text = re.sub(r"-\n(\S)", r"\1", text)
+    # 5. Normalize line endings
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    # 6. Strip trailing whitespace per line
+    text = "\n".join(line.rstrip() for line in text.split("\n"))
+    # 7. Collapse 3+ consecutive blank lines to 2
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    # 8. Collapse multiple inline spaces/tabs to a single space
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    # 9. Final strip
+    text = text.strip()
+
+    logger.debug("Text cleaning: %d → %d characters", original_len, len(text))
+    return text

--- a/backend/tests/test_text_cleaning_service.py
+++ b/backend/tests/test_text_cleaning_service.py
@@ -1,0 +1,207 @@
+"""Unit tests for the text cleaning and normalization service."""
+
+import pytest
+
+from services.text_cleaning_service import clean_text
+
+
+class TestEdgeCases:
+    def test_empty_string_returns_empty(self):
+        assert clean_text("") == ""
+
+    def test_whitespace_only_returns_empty(self):
+        assert clean_text("   \n\n\t  ") == ""
+
+    def test_none_like_passthrough_is_not_called(self):
+        # Sanity: function is only called with str; empty string is safe
+        result = clean_text("")
+        assert result == ""
+
+
+class TestUnicodeNormalization:
+    def test_ligatures_are_expanded(self):
+        # ﬁ (U+FB01 LATIN SMALL LIGATURE FI) → "fi"
+        result = clean_text("ﬁle ﬂow")
+        assert result == "file flow"
+
+    def test_non_breaking_space_becomes_regular_space(self):
+        # U+00A0 NON-BREAKING SPACE → regular space, then collapsed
+        result = clean_text("hello\u00a0world")
+        assert result == "hello world"
+
+    def test_fullwidth_digits_normalized(self):
+        # Fullwidth digit characters normalized to ASCII
+        result = clean_text("\uff11\uff12\uff13")
+        assert result == "123"
+
+
+class TestControlCharacterRemoval:
+    def test_null_bytes_removed(self):
+        result = clean_text("hel\x00lo")
+        assert result == "hello"
+
+    def test_bell_and_backspace_removed(self):
+        result = clean_text("te\x07st\x08")
+        assert result == "test"
+
+    def test_vertical_tab_and_form_feed_removed(self):
+        result = clean_text("a\x0bb\x0cc")
+        assert result == "abc"
+
+    def test_newlines_preserved(self):
+        result = clean_text("line one\nline two")
+        assert result == "line one\nline two"
+
+    def test_tabs_preserved_within_line(self):
+        # Tabs at the start of a line are kept (indented content)
+        result = clean_text("header\n\tindented")
+        assert result == "header\n\tindented"
+
+
+class TestSoftHyphenRemoval:
+    def test_soft_hyphen_removed(self):
+        # U+00AD SOFT HYPHEN should be invisible and removed
+        result = clean_text("connec\u00adtion")
+        assert result == "connection"
+
+    def test_regular_hyphen_preserved(self):
+        result = clean_text("well-known")
+        assert result == "well-known"
+
+
+class TestHyphenatedLineBreaks:
+    def test_hyphenated_line_break_rejoined(self):
+        # PDF word-wrap artifact: "connec-\ntion" → "connection"
+        result = clean_text("connec-\ntion")
+        assert result == "connection"
+
+    def test_hyphenated_line_break_with_leading_space(self):
+        # Hyphen at end of line followed by word on next line
+        result = clean_text("This is a connec-\ntion example.")
+        assert result == "This is a connection example."
+
+    def test_hyphen_at_end_of_line_before_blank_line_preserved(self):
+        # A trailing hyphen before a blank line is NOT a word-break artifact
+        result = clean_text("some text-\n\nnext paragraph")
+        assert "text-" in result
+
+    def test_standalone_hyphen_line_not_joined(self):
+        # A line that is just "- item" (list marker) should not be mangled
+        result = clean_text("- first item\n- second item")
+        assert "- first item" in result
+        assert "- second item" in result
+
+
+class TestLineEndingNormalization:
+    def test_windows_crlf_normalized(self):
+        result = clean_text("line one\r\nline two")
+        assert result == "line one\nline two"
+
+    def test_old_mac_cr_normalized(self):
+        result = clean_text("line one\rline two")
+        assert result == "line one\nline two"
+
+    def test_mixed_line_endings_normalized(self):
+        result = clean_text("a\r\nb\rc\nd")
+        assert result == "a\nb\nc\nd"
+
+
+class TestTrailingWhitespace:
+    def test_trailing_spaces_stripped_per_line(self):
+        result = clean_text("hello   \nworld  ")
+        assert result == "hello\nworld"
+
+    def test_trailing_tab_stripped_per_line(self):
+        result = clean_text("line\t")
+        assert result == "line"
+
+    def test_multiple_leading_spaces_collapsed(self):
+        # Multiple leading spaces are collapsed to one — PDF indentation is
+        # a layout artifact and not semantically meaningful for prose documents.
+        result = clean_text("header\n    indented line\nfooter")
+        lines = result.split("\n")
+        assert lines[1] == " indented line"
+
+
+class TestBlankLineCollapse:
+    def test_three_blank_lines_collapsed_to_two(self):
+        result = clean_text("para one\n\n\n\npara two")
+        assert result == "para one\n\npara two"
+
+    def test_many_blank_lines_collapsed_to_two(self):
+        result = clean_text("a\n\n\n\n\n\n\nb")
+        assert result == "a\n\nb"
+
+    def test_two_blank_lines_preserved(self):
+        result = clean_text("a\n\nb")
+        assert result == "a\n\nb"
+
+    def test_single_blank_line_preserved(self):
+        result = clean_text("a\n\nb")
+        assert result == "a\n\nb"
+
+
+class TestInlineSpaceCollapse:
+    def test_multiple_spaces_collapsed(self):
+        result = clean_text("hello     world")
+        assert result == "hello world"
+
+    def test_mixed_spaces_and_tabs_collapsed(self):
+        result = clean_text("col1\t\t\tcol2")
+        assert result == "col1 col2"
+
+    def test_single_space_untouched(self):
+        result = clean_text("hello world")
+        assert result == "hello world"
+
+
+class TestFinalStrip:
+    def test_leading_newlines_stripped(self):
+        result = clean_text("\n\nhello")
+        assert result == "hello"
+
+    def test_trailing_newlines_stripped(self):
+        result = clean_text("hello\n\n")
+        assert result == "hello"
+
+    def test_surrounding_whitespace_stripped(self):
+        result = clean_text("   hello world   ")
+        assert result == "hello world"
+
+
+class TestRealWorldPatterns:
+    def test_pdf_page_with_header_and_footer_whitespace(self):
+        """Simulates a PDF page dump with extra blank lines from header/footer separation."""
+        raw = (
+            "\n\n\n"
+            "CHAPTER 1\n\n\n\n"
+            "Introduction\n\n"
+            "This document describes the system archi-\n"
+            "tecture and its components.\n\n\n\n\n"
+            "Page 1\n"
+        )
+        result = clean_text(raw)
+        # Hyphenated break rejoined
+        assert "architecture" in result
+        # Excess blank lines collapsed
+        assert "\n\n\n" not in result
+        # Page number line preserved (we don't strip arbitrary lines)
+        assert "Page 1" in result
+
+    def test_txt_file_with_inconsistent_whitespace(self):
+        """Simulates a TXT dump with tabs and multiple spaces."""
+        raw = "Name:\t\tJohn   Doe\nAge:\t\t 30\nCity:   New   York"
+        result = clean_text(raw)
+        assert result == "Name: John Doe\nAge: 30\nCity: New York"
+
+    def test_combined_ligature_and_hyphen_artifact(self):
+        """PDF may have both ligatures and hyphenated breaks in the same text."""
+        raw = "The ﬁle con-\ntains important infor-\nmation."
+        result = clean_text(raw)
+        assert result == "The file contains important information."
+
+    def test_unicode_normalization_with_control_chars(self):
+        """Control characters embedded among normal unicode text."""
+        raw = "Hello\x00 \uff37\uff4f\uff52\uff4c\uff44!"
+        result = clean_text(raw)
+        assert result == "Hello World!"


### PR DESCRIPTION
# feat(ingestion): Text Cleaning & Normalization Pipeline Stage
-closes #24 
## Summary

- Introduces a dedicated `text_cleaning_service` that normalizes extracted document text **before** it enters the chunking and embedding pipeline
- Fixes common PDF/TXT extraction artifacts (hyphenated line breaks, ligatures, control characters, inconsistent whitespace) that degrade chunk quality and RAG answer accuracy
- Wires the cleaning step into `IngestionPipeline.process_document()` between extraction and chunking with zero changes to the public API

## Problem

Many uploaded documents (PDFs, TXT files) produce messy raw text after extraction:

- **PDF word-wrap artifacts**: `connec-\ntion` — the PDF renderer inserts a hard hyphen at the line boundary, splitting a single word across lines
- **Unicode ligatures**: Characters like `ﬁ` (U+FB01) are not decomposed by pypdf, leaving tokens that don't match standard vocabulary
- **Non-breaking spaces** (U+00A0) and **soft hyphens** (U+00AD) are invisible but break tokenization
- **Control characters** (null bytes, bell, backspace, form feed) from binary PDFs corrupt the text stream
- **Excessive blank lines** from page headers/footers create artificially short chunks
- **Multiple inline spaces/tabs** from PDF column layout inflate token count without adding meaning
- **Mixed line endings** (CRLF, CR) from Windows/Mac-originating TXT files

All of this raw noise was previously passed directly to `RecursiveCharacterTextSplitter`, producing low-quality chunks and degraded embedding similarity scores.

## Solution

### New file: `backend/services/text_cleaning_service.py`

A single `clean_text(text: str) -> str` function applying 9 normalization steps in order:

| Step | Transform |
|------|-----------|
| 1 | Unicode NFKC normalization (ligatures, non-breaking spaces, fullwidth chars) |
| 2 | Remove non-printable control characters (keep `\n`, `\r`, `\t`) |
| 3 | Remove soft hyphens (U+00AD) |
| 4 | Rejoin hyphenated line breaks (`connec-\ntion` → `connection`) |
| 5 | Normalize line endings to `\n` |
| 6 | Strip trailing whitespace per line |
| 7 | Collapse 3+ consecutive blank lines to 2 (preserve paragraph breaks) |
| 8 | Collapse multiple inline spaces/tabs to a single space |
| 9 | Strip leading/trailing whitespace from the full document |

### Modified: `backend/services/ingestion_pipeline.py`

```
extract_text_from_file()  →  clean_text()  →  empty check  →  chunking  →  embedding  →  storage
```

`clean_text()` is called immediately after extraction. The subsequent empty-text guard checks the cleaned result, so documents that yield only control characters or whitespace are correctly rejected.

### New file: `backend/tests/test_text_cleaning_service.py`

37 unit tests covering:
- Edge cases (empty string, whitespace-only input)
- Each cleaning step in isolation
- Real-world PDF patterns (hyphenated breaks + ligatures combined, page header/footer blank lines)
- Real-world TXT patterns (tab-separated fields, multiple inline spaces)

## Test Results

```
37 passed in 0.04s   (test_text_cleaning_service.py)
 5 passed in 1.07s   (test_ingestion_pipeline.py — no regressions)
```

## Files Changed

| File | Change |
|------|--------|
| `backend/services/text_cleaning_service.py` | New — cleaning module |
| `backend/services/ingestion_pipeline.py` | Modified — import + one-line call after extraction |
| `backend/tests/test_text_cleaning_service.py` | New — 37 unit tests |
