### PR TITLE
feat: add document upload functionality to chat page

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Send, Paperclip, Bot, User } from "lucide-react";
+import { Send, Bot, User, FileText } from "lucide-react";
+import UploadButton from "../components/UploadButton";
+import UploadModal from "../components/UploadModal";
 
 type Message = {
   id: number;
@@ -19,6 +21,8 @@ const sampleMessages: Message[] = [
 export default function ChatPage() {
   const [messages, setMessages] = useState<Message[]>(sampleMessages);
   const [input, setInput] = useState("");
+  const [showModal, setShowModal] = useState(false);
+  const [uploadedFile, setUploadedFile] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -38,10 +42,23 @@ export default function ChatPage() {
     if (e.key === "Enter") handleSend();
   };
 
+  const handleUploadSuccess = (fileName: string) => {
+    setUploadedFile(fileName);
+    setMessages((prev) => [
+      ...prev,
+      { id: Date.now(), sender: "ai", text: `Document "${fileName}" uploaded! You can now ask questions about it.` },
+    ]);
+  };
+
   return (
     <div className="flex flex-col h-screen bg-gray-950 text-white">
+      {showModal && (
+        <UploadModal
+          onClose={() => setShowModal(false)}
+          onUploadSuccess={handleUploadSuccess}
+        />
+      )}
 
-      {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
         {messages.map((msg) => (
           <div
@@ -59,12 +76,17 @@ export default function ChatPage() {
         <div ref={bottomRef} />
       </div>
 
-      {/* Input */}
+      {uploadedFile && (
+        <div className="px-4 py-2 bg-gray-900 border-t border-gray-800 flex items-center gap-2">
+          <FileText size={14} className="text-indigo-400" />
+          <span className="text-xs text-gray-400">Active document:</span>
+          <span className="text-xs text-indigo-400 font-medium">{uploadedFile}</span>
+        </div>
+      )}
+
       <div className="px-4 py-3 border-t border-gray-800 bg-gray-900">
         <div className="flex items-center gap-2 bg-gray-800 rounded-xl px-4 py-2">
-          <button className="text-gray-400 hover:text-white transition">
-            <Paperclip size={18} />
-          </button>
+          <UploadButton onClick={() => setShowModal(true)} />
           <input
             type="text"
             value={input}

--- a/frontend-demo/app/components/UploadButton.tsx
+++ b/frontend-demo/app/components/UploadButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Paperclip } from "lucide-react";
+
+type Props = {
+  onClick: () => void;
+};
+
+export default function UploadButton({ onClick }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-gray-400 hover:text-white transition"
+      title="Upload document"
+    >
+      <Paperclip size={18} />
+    </button>
+  );
+}

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { X, Upload } from "lucide-react";
+
+type Props = {
+  onClose: () => void;
+  onUploadSuccess: (fileName: string) => void;
+};
+
+export default function UploadModal({ onClose, onUploadSuccess }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [status, setStatus] = useState<"idle" | "uploading" | "success" | "error">("idle");
+  const [error, setError] = useState("");
+
+  const handleFile = async (file: File) => {
+    setStatus("uploading");
+    setError("");
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch("http://localhost:8000/upload", {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) throw new Error("Upload failed");
+      setStatus("success");
+      onUploadSuccess(file.name);
+      setTimeout(() => onClose(), 1000);
+    } catch {
+      setStatus("error");
+      setError("Upload failed. Please try again.");
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-gray-900 rounded-2xl p-6 w-full max-w-md mx-4 border border-gray-700">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-white font-semibold text-lg">Upload Document</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">
+            <X size={20} />
+          </button>
+        </div>
+        <div
+          onDrop={handleDrop}
+          onDragOver={(e) => e.preventDefault()}
+          onClick={() => inputRef.current?.click()}
+          className="border-2 border-dashed border-gray-600 hover:border-indigo-500 rounded-xl p-10 flex flex-col items-center justify-center cursor-pointer transition"
+        >
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".pdf,.txt,.docx"
+            onChange={handleChange}
+            className="hidden"
+          />
+          {status === "uploading" && <p className="text-indigo-400 text-sm animate-pulse">Uploading...</p>}
+          {status === "success" && <p className="text-green-400 text-sm">✅ Upload successful!</p>}
+          {status === "error" && <p className="text-red-400 text-sm">{error}</p>}
+          {status === "idle" && (
+            <>
+              <Upload size={32} className="text-gray-500 mb-3" />
+              <p className="text-gray-400 text-sm text-center">
+                Drag & drop or <span className="text-indigo-400">click to browse</span>
+              </p>
+              <p className="text-gray-600 text-xs mt-1">PDF, TXT, DOCX supported</p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #5

## What I did
Added document upload support to the chat page.

- Created `UploadButton` component (replaces the non-functional paperclip button)
- Created `UploadModal` with drag & drop + file browser support
- Shows uploaded filename below chat when document is active
- Connects to `/upload` backend endpoint
- Basic error handling if upload fails

## Testing
Run the frontend and click the paperclip icon in chat to try it out.
Tested with PDF and TXT files.