### PR TITLE
Add query transformations and fix chunk dedupe by document

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,10 @@ POSTGRES_DB=postgres
 # CHUNK_SIZE=1000
 # CHUNK_OVERLAP=200
 
+# ── Query Transformations ─────────────────────────────────────────────────
+# QUERY_TRANSFORMATION_ENABLED=false
+# QUERY_TRANSFORMATION_STRATEGY=rewrite  # rewrite | expand | stepback
+
 # ── LLM / Prompt ──────────────────────────────────────────────────────────
 # Path to system prompt file (default: backend/prompts/default_system.txt)
 # SYSTEM_PROMPT_PATH=

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -21,6 +21,7 @@ logger.debug(f"Loaded environment variables from {dotenv_path}")
 # Statuses that indicate a document was mid-flight when the server last stopped.
 STALE_INGESTION_STATUSES = ["queued", "retrying", "extracting", "chunking", "embedding", "storing"]
 VALID_CHUNKING_STRATEGIES = {"fixed", "paragraph", "semantic"}
+VALID_QUERY_TRANSFORMATION_STRATEGIES = {"rewrite", "expand", "stepback"}
 
 
 def _get_chunking_strategy() -> str:
@@ -29,6 +30,17 @@ def _get_chunking_strategy() -> str:
         valid_strategies = ", ".join(sorted(VALID_CHUNKING_STRATEGIES))
         raise ValueError(
             f"Invalid CHUNKING_STRATEGY={strategy!r}. "
+            f"Expected one of: {valid_strategies}."
+        )
+    return strategy
+
+
+def _get_query_transformation_strategy() -> str:
+    strategy = os.getenv("QUERY_TRANSFORMATION_STRATEGY", "rewrite").strip().lower()
+    if strategy not in VALID_QUERY_TRANSFORMATION_STRATEGIES:
+        valid_strategies = ", ".join(sorted(VALID_QUERY_TRANSFORMATION_STRATEGIES))
+        raise ValueError(
+            f"Invalid QUERY_TRANSFORMATION_STRATEGY={strategy!r}. "
             f"Expected one of: {valid_strategies}."
         )
     return strategy
@@ -55,6 +67,10 @@ class Settings:
     CHUNK_SIZE: int = max(1, int(os.getenv("CHUNK_SIZE", "1000")))
     CHUNK_OVERLAP: int = max(0, int(os.getenv("CHUNK_OVERLAP", "200")))
     CHUNKING_STRATEGY: str = _get_chunking_strategy()
+    QUERY_TRANSFORMATION_ENABLED: bool = os.getenv(
+        "QUERY_TRANSFORMATION_ENABLED", "false"
+    ).lower() in ("1", "true", "yes")
+    QUERY_TRANSFORMATION_STRATEGY: str = _get_query_transformation_strategy()
     RETRIEVAL_MAX_CONCURRENCY: int = max(1, int(os.getenv("RETRIEVAL_MAX_CONCURRENCY", "8")))
     SUPABASE_IO_CONCURRENCY: int = max(1, int(os.getenv("SUPABASE_IO_CONCURRENCY", "16")))
     CHAT_BATCH_MAX_ITEMS: int = max(1, int(os.getenv("CHAT_BATCH_MAX_ITEMS", "20")))

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -4,6 +4,7 @@ import asyncio
 from core.config import config
 from db import find_similar_chunks
 from services.context_service import build_context_from_chunks
+from services.query_service import transform_query
 
 logger = logging.getLogger(__name__)
 
@@ -129,12 +130,22 @@ async def answer_question_for_document(
     """
     logger.info(f"Starting chat for document {doc_id}")
 
-    query_embedding = await get_embedding(question)
-    matching_chunks = await _retrieve_chunks_for_documents(
-        doc_ids=[doc_id],
-        query_embedding=query_embedding,
-        match_count=match_count,
-    )
+    transformed_queries = await transform_query(question)
+    query_embeddings = await get_embeddings(transformed_queries)
+    all_chunks: list = []
+    seen_chunk_keys: set = set()
+    for query_embedding in query_embeddings:
+        chunks = await _retrieve_chunks_for_documents(
+            doc_ids=[doc_id],
+            query_embedding=query_embedding,
+            match_count=match_count,
+        )
+        for chunk in chunks:
+            key = (chunk.document_id, chunk.chunk_index)
+            if key not in seen_chunk_keys:
+                seen_chunk_keys.add(key)
+                all_chunks.append(chunk)
+    matching_chunks = all_chunks
     context = build_context_from_chunks(matching_chunks)
     answer = await generate_answer(question, context)
 
@@ -188,10 +199,14 @@ async def answer_questions_for_documents_batch(
             }
         )
 
-    embeddings = await get_embeddings([q["question"] for q in normalized_queries])
-    if len(embeddings) != len(normalized_queries):
+    transformed_query_lists = await asyncio.gather(
+        *[transform_query(q["question"]) for q in normalized_queries]
+    )
+    flat_queries = [q for queries in transformed_query_lists for q in queries]
+    flat_embeddings = await get_embeddings(flat_queries)
+    if len(flat_embeddings) != len(flat_queries):
         mismatch_message = (
-            f"Embedding mismatch: got {len(embeddings)} embeddings for {len(normalized_queries)} queries"
+            f"Embedding mismatch: got {len(flat_embeddings)} embeddings for {len(flat_queries)} queries"
         )
         logger.error(mismatch_message)
         return [
@@ -208,13 +223,31 @@ async def answer_questions_for_documents_batch(
             for query in normalized_queries
         ]
 
-    async def _process_query(query: dict, query_embedding: list[float]) -> dict:
+    per_query_embeddings: list[list[list[float]]] = []
+    offset = 0
+    for tq_list in transformed_query_lists:
+        n = len(tq_list)
+        per_query_embeddings.append(flat_embeddings[offset : offset + n])
+        offset += n
+
+    async def _process_query(
+        query: dict, query_embeddings: list[list[float]]
+    ) -> dict:
         try:
-            matching_chunks = await _retrieve_chunks_for_documents(
-                doc_ids=query["doc_ids"],
-                query_embedding=query_embedding,
-                match_count=query["match_count"],
-            )
+            all_chunks: list = []
+            seen_chunk_keys: set = set()
+            for query_embedding in query_embeddings:
+                chunks = await _retrieve_chunks_for_documents(
+                    doc_ids=query["doc_ids"],
+                    query_embedding=query_embedding,
+                    match_count=query["match_count"],
+                )
+                for chunk in chunks:
+                    key = (chunk.document_id, chunk.chunk_index)
+                    if key not in seen_chunk_keys:
+                        seen_chunk_keys.add(key)
+                        all_chunks.append(chunk)
+            matching_chunks = all_chunks
             context = build_context_from_chunks(matching_chunks)
             answer = await generate_answer(query["question"], context)
 
@@ -245,7 +278,7 @@ async def answer_questions_for_documents_batch(
 
     return await asyncio.gather(
         *[
-            _process_query(query, embedding)
-            for query, embedding in zip(normalized_queries, embeddings)
+            _process_query(query, embeddings)
+            for query, embeddings in zip(normalized_queries, per_query_embeddings)
         ]
     )

--- a/backend/services/query_service.py
+++ b/backend/services/query_service.py
@@ -1,0 +1,99 @@
+"""Query transformation for retrieval (rewrite, expand, step-back)."""
+
+import asyncio
+import logging
+
+from google.genai import types
+
+from core.config import config
+
+logger = logging.getLogger(__name__)
+
+_TRANSFORM_TEMPERATURE = 0.1
+_TRANSFORM_MAX_OUTPUT_TOKENS = 512
+
+
+async def _llm_transform(system_instruction: str, user_text: str) -> str | None:
+    from services.answer_service import client as _genai_client
+
+    config_obj = types.GenerateContentConfig(
+        system_instruction=system_instruction,
+        temperature=_TRANSFORM_TEMPERATURE,
+        max_output_tokens=_TRANSFORM_MAX_OUTPUT_TOKENS,
+    )
+    try:
+        response = await asyncio.to_thread(
+            _genai_client.models.generate_content,
+            model="gemini-2.5-flash",
+            contents=user_text,
+            config=config_obj,
+        )
+        text = (response.text or "").strip()
+        return text if text else None
+    except Exception as e:
+        logger.warning(
+            "Query transformation LLM call failed (%s): %s",
+            type(e).__name__,
+            e,
+            exc_info=True,
+        )
+        return None
+
+
+async def rewrite_query(question: str) -> str:
+    system_instruction = (
+        "You are a query rewriting assistant. Rephrase the following question to be "
+        "more specific and retrieval-friendly for semantic search over documents. "
+        "Return only the rewritten query, nothing else."
+    )
+    rewritten = await _llm_transform(system_instruction, question)
+    if rewritten is None:
+        return question
+    return rewritten
+
+
+async def expand_query(question: str) -> list[str]:
+    system_instruction = (
+        "You are a query expansion assistant. Generate exactly 2 alternative phrasings "
+        "of the following question for semantic search. Return only the alternatives, "
+        "one per line, no numbering, no explanation."
+    )
+    raw = await _llm_transform(system_instruction, question)
+    if raw is None:
+        return [question]
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    alternatives = lines[:2]
+    if not alternatives:
+        return [question]
+    return [question, *alternatives]
+
+
+async def stepback_query(question: str) -> list[str]:
+    system_instruction = (
+        "You are a step-back prompting assistant. Given a specific question, identify "
+        "the broader concept or principle it relates to. Return only the broader question, "
+        "nothing else."
+    )
+    broader = await _llm_transform(system_instruction, question)
+    if broader is None:
+        return [question]
+    return [question, broader]
+
+
+async def transform_query(question: str) -> list[str]:
+    if not config.QUERY_TRANSFORMATION_ENABLED:
+        return [question]
+
+    strategy = config.QUERY_TRANSFORMATION_STRATEGY
+    if strategy == "rewrite":
+        return [await rewrite_query(question)]
+    if strategy == "expand":
+        return await expand_query(question)
+    if strategy == "stepback":
+        return await stepback_query(question)
+
+    logger.warning(
+        "Unknown QUERY_TRANSFORMATION_STRATEGY=%r; returning original question unchanged",
+        strategy,
+    )
+    return [question]

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -1,10 +1,20 @@
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+import services.chat_service as chat_service_mod
 from services.chat_service import answer_question_for_document
 from services.chat_service import answer_questions_for_documents_batch
+
+
+@pytest.fixture(autouse=True)
+def _disable_query_transformation_for_chat_tests(monkeypatch):
+    monkeypatch.setattr(
+        chat_service_mod.config, "QUERY_TRANSFORMATION_ENABLED", False
+    )
 
 
 @dataclass
@@ -16,15 +26,33 @@ class _FakeChunk:
     file_name: Optional[str] = None
     page_number: Optional[int] = None
     chunk_index: Optional[int] = None
+    document_id: Optional[str] = None
 
 
 def test_answer_question_for_document_orchestrates_flow():
     chunks = [
-        _FakeChunk(id="c1", chunk_text="chunk one", file_name="doc.pdf", page_number=1, chunk_index=0),
-        _FakeChunk(id="c2", chunk_text="chunk two", file_name="doc.pdf", page_number=2, chunk_index=1),
+        _FakeChunk(
+            id="c1",
+            chunk_text="chunk one",
+            file_name="doc.pdf",
+            page_number=1,
+            chunk_index=0,
+            document_id="doc-123",
+        ),
+        _FakeChunk(
+            id="c2",
+            chunk_text="chunk two",
+            file_name="doc.pdf",
+            page_number=2,
+            chunk_index=1,
+            document_id="doc-123",
+        ),
     ]
 
-    with patch("services.chat_service.get_embedding", new=AsyncMock(return_value=[0.1, 0.2])) as mock_embedding, patch(
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ) as mock_embeddings, patch(
         "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=chunks)
     ) as mock_find, patch(
         "services.chat_service.build_context_from_chunks", return_value="combined context"
@@ -46,7 +74,7 @@ def test_answer_question_for_document_orchestrates_flow():
         {"file_name": "doc.pdf", "page_number": 1, "chunk_index": 0},
         {"file_name": "doc.pdf", "page_number": 2, "chunk_index": 1},
     ]
-    mock_embedding.assert_awaited_once_with("What is this about?")
+    mock_embeddings.assert_awaited_once_with(["What is this about?"])
     mock_find.assert_awaited_once_with(
         doc_id="doc-123",
         query_embedding=[0.1, 0.2],
@@ -63,7 +91,15 @@ def test_answer_questions_for_documents_batch_processes_queries():
     ]
 
     async def fake_find_similar_chunks(doc_id: str, query_embedding: list[float], match_count: int):
-        return [_FakeChunk(id=f"{doc_id}-1", chunk_text=f"chunk-{doc_id}-{match_count}")]
+        # Same chunk_index across docs; distinct document_id so dedupe keeps one chunk per document.
+        return [
+            _FakeChunk(
+                id=f"{doc_id}-1",
+                chunk_text=f"chunk-{doc_id}-{match_count}",
+                chunk_index=0,
+                document_id=doc_id,
+            )
+        ]
 
     with patch(
         "services.chat_service.get_embeddings",
@@ -109,7 +145,13 @@ def test_answer_questions_for_documents_batch_respects_retrieval_concurrency_lim
         max_active_calls = max(max_active_calls, active_calls)
         await asyncio.sleep(0.01)
         active_calls -= 1
-        return [_FakeChunk(id=f"{doc_id}-1", chunk_text=f"chunk-{doc_id}")]
+        return [
+            _FakeChunk(
+                id=f"{doc_id}-1",
+                chunk_text=f"chunk-{doc_id}",
+                document_id=doc_id,
+            )
+        ]
 
     with patch(
         "services.chat_service.config.RETRIEVAL_MAX_CONCURRENCY",
@@ -149,7 +191,11 @@ def test_answer_questions_for_documents_batch_returns_partial_failures():
         new=AsyncMock(return_value=[[0.1], [0.2]]),
     ), patch(
         "services.chat_service.find_similar_chunks",
-        new=AsyncMock(return_value=[_FakeChunk(id="c1", chunk_text="ctx")]),
+        new=AsyncMock(
+            side_effect=lambda doc_id, query_embedding, match_count: [
+                _FakeChunk(id="c1", chunk_text="ctx", document_id=doc_id, chunk_index=0)
+            ]
+        ),
     ), patch(
         "services.chat_service.build_context_from_chunks",
         return_value="ctx",
@@ -184,11 +230,27 @@ def test_answer_questions_for_documents_batch_rejects_duplicate_doc_ids():
 
 def test_answer_question_for_document_includes_sources_with_correct_shape():
     chunks = [
-        _FakeChunk(id="c1", chunk_text="text a", file_name="report.pdf", page_number=3, chunk_index=0),
-        _FakeChunk(id="c2", chunk_text="text b", file_name="report.pdf", page_number=5, chunk_index=1),
+        _FakeChunk(
+            id="c1",
+            chunk_text="text a",
+            file_name="report.pdf",
+            page_number=3,
+            chunk_index=0,
+            document_id="doc-1",
+        ),
+        _FakeChunk(
+            id="c2",
+            chunk_text="text b",
+            file_name="report.pdf",
+            page_number=5,
+            chunk_index=1,
+            document_id="doc-1",
+        ),
     ]
 
-    with patch("services.chat_service.get_embedding", new=AsyncMock(return_value=[0.1])), patch(
+    with patch(
+        "services.chat_service.get_embeddings", new=AsyncMock(return_value=[[0.1]])
+    ), patch(
         "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=chunks)
     ), patch(
         "services.chat_service.build_context_from_chunks", return_value="ctx"
@@ -206,10 +268,19 @@ def test_answer_question_for_document_includes_sources_with_correct_shape():
 
 def test_answer_question_for_document_sources_none_fields_for_txt():
     chunks = [
-        _FakeChunk(id="c1", chunk_text="plain text", file_name="notes.txt", page_number=None, chunk_index=0),
+        _FakeChunk(
+            id="c1",
+            chunk_text="plain text",
+            file_name="notes.txt",
+            page_number=None,
+            chunk_index=0,
+            document_id="doc-txt",
+        ),
     ]
 
-    with patch("services.chat_service.get_embedding", new=AsyncMock(return_value=[0.1])), patch(
+    with patch(
+        "services.chat_service.get_embeddings", new=AsyncMock(return_value=[[0.1]])
+    ), patch(
         "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=chunks)
     ), patch(
         "services.chat_service.build_context_from_chunks", return_value="ctx"
@@ -227,7 +298,14 @@ def test_batch_answer_includes_sources_in_ok_responses():
     queries = [{"question": "Q1", "doc_ids": ["doc-a"]}]
 
     chunks = [
-        _FakeChunk(id="c1", chunk_text="ctx", file_name="slides.pdf", page_number=2, chunk_index=0),
+        _FakeChunk(
+            id="c1",
+            chunk_text="ctx",
+            file_name="slides.pdf",
+            page_number=2,
+            chunk_index=0,
+            document_id="doc-a",
+        ),
     ]
 
     with patch(

--- a/backend/tests/test_query_service.py
+++ b/backend/tests/test_query_service.py
@@ -1,0 +1,123 @@
+"""Tests for query transformation strategies."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+import services.query_service as query_service_mod
+from core.config import config
+from services.query_service import (
+    expand_query,
+    rewrite_query,
+    stepback_query,
+    transform_query,
+)
+
+
+def test_transform_query_returns_original_when_disabled(monkeypatch):
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_ENABLED", False)
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_STRATEGY", "expand")
+
+    result = asyncio.run(transform_query("original question"))
+
+    assert result == ["original question"]
+
+
+@pytest.mark.asyncio
+async def test_rewrite_strategy_returns_single_transformed_query(monkeypatch):
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_ENABLED", True)
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_STRATEGY", "rewrite")
+
+    async def fake_llm(system_instruction: str, user_text: str) -> str | None:
+        return "retrieval friendly version"
+
+    monkeypatch.setattr(query_service_mod, "_llm_transform", fake_llm)
+
+    result = await transform_query("user question")
+
+    assert result == ["retrieval friendly version"]
+
+
+@pytest.mark.asyncio
+async def test_expand_strategy_returns_original_plus_two_alternatives(monkeypatch):
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_ENABLED", True)
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_STRATEGY", "expand")
+
+    async def fake_llm(system_instruction: str, user_text: str) -> str | None:
+        return "first alt\nsecond alt"
+
+    monkeypatch.setattr(query_service_mod, "_llm_transform", fake_llm)
+
+    result = await transform_query("base q")
+
+    assert result == ["base q", "first alt", "second alt"]
+
+
+@pytest.mark.asyncio
+async def test_stepback_strategy_returns_original_and_broader_question(monkeypatch):
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_ENABLED", True)
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_STRATEGY", "stepback")
+
+    async def fake_llm(system_instruction: str, user_text: str) -> str | None:
+        return "What are the general principles of X?"
+
+    monkeypatch.setattr(query_service_mod, "_llm_transform", fake_llm)
+
+    result = await transform_query("specific detail about X?")
+
+    assert result == [
+        "specific detail about X?",
+        "What are the general principles of X?",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rewrite_degrades_on_llm_failure(monkeypatch):
+    monkeypatch.setattr(
+        query_service_mod,
+        "_llm_transform",
+        AsyncMock(return_value=None),
+    )
+
+    result = await rewrite_query("fallback me")
+
+    assert result == "fallback me"
+
+
+@pytest.mark.asyncio
+async def test_expand_degrades_on_llm_failure(monkeypatch):
+    monkeypatch.setattr(
+        query_service_mod,
+        "_llm_transform",
+        AsyncMock(return_value=None),
+    )
+
+    result = await expand_query("only me")
+
+    assert result == ["only me"]
+
+
+@pytest.mark.asyncio
+async def test_stepback_degrades_on_llm_failure(monkeypatch):
+    monkeypatch.setattr(
+        query_service_mod,
+        "_llm_transform",
+        AsyncMock(return_value=None),
+    )
+
+    result = await stepback_query("solo")
+
+    assert result == ["solo"]
+
+
+def test_unknown_strategy_logs_warning_and_returns_original(caplog, monkeypatch):
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_ENABLED", True)
+    monkeypatch.setattr(config, "QUERY_TRANSFORMATION_STRATEGY", "not-a-real-strategy")
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(transform_query("unchanged"))
+
+    assert result == ["unchanged"]
+    assert "Unknown QUERY_TRANSFORMATION_STRATEGY" in caplog.text


### PR DESCRIPTION


**What's solid**

- `query_service.py` is well-isolated — lazy import of the genai client avoids circular dependencies ✅
- All three strategies (`rewrite`, `expand`, `stepback`) fall back to the original question on any LLM failure — retrieval never breaks if the transformation call fails ✅
- `generate_answer` always receives the original question, not the transformed version — the user sees their own words reflected back ✅
- Batch path correctly flattens all transformed queries into a single `get_embeddings` call, then reconstructs per-query embedding lists ✅
- Config follows established pattern with validation function matching `_get_chunking_strategy()` ✅
- `QUERY_TRANSFORMATION_ENABLED` defaults to `false` — existing behavior is completely unchanged unless explicitly opted in ✅
- Test autouse fixture forces transformation off so existing chat tests stay stable ✅

**Dedup fix included**

Chunk deduplication key changed from `chunk_index` alone to `(document_id, chunk_index)` — the original key was incorrect when multiple documents were involved since two different documents can share the same `chunk_index`. Tests updated to encode the correct behavior explicitly.

---

Closes #126.