### PR TITLE
fix: add .gitattributes to prevent CRLF breaking Docker on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+.gitattributes text eol=lf 


### PR DESCRIPTION
## What does this PR do?

Fixes the API container failing to start on Windows with:
`exec /app/entrypoint.sh: no such file or directory`

On Windows, Git checks out shell scripts with CRLF line endings.
The Linux container interprets the shebang as `#!/bin/bash\r`, which doesn't exist, causing the cryptic error.

### Changes:
- Add `.gitattributes` with `*.sh text eol=lf` to prevent CRLF on shell scripts
- Convert `entrypoint.sh` and `wait-for-db.sh` to LF endings

## How was it tested?
- [x] `docker-compose up --build` — API container starts successfully
- [x] `http://localhost:8000` returns expected response
- [x] Verified `GEN_AI_KEY` loads correctly via python-dotenv
- [x] Checked existing functionality still works

Closes #161