### PR TITLE
fix(frontend-demo): align chat page with backend-connected flow

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useState, useRef, useEffect } from "react";
 import { Send, Bot, User, FileText, X } from "lucide-react";
@@ -28,11 +28,12 @@ type AttachmentState = {
   status: "processing" | "ready" | "failed";
 };
 
-const sampleMessages: Message[] = [
-  { id: 1, sender: "ai", text: "Hello! I am ChatVector. Upload a document and I will help you find answers from it." },
-  { id: 2, sender: "user", text: "What is RAG?" },
-  { id: 3, sender: "ai", text: "RAG stands for Retrieval-Augmented Generation. It retrieves relevant context from your documents before generating an answer." },
-  { id: 4, sender: "user", text: "That sounds cool! Can I upload a PDF?" },
+const welcomeMessages: Message[] = [
+  {
+    id: 1,
+    sender: "ai",
+    text: "Hello! I'm ChatVector. Upload a document and I'll help you find answers from it.",
+  },
 ];
 
 export default function ChatPage() {
@@ -50,9 +51,11 @@ export default function ChatPage() {
 
   useEffect(() => {
     if (!attachment || attachment.status !== "processing") return;
+
     const docId = attachment.documentId;
     const statusPath = attachment.statusEndpoint;
     let cancelled = false;
+
     const poll = async () => {
       if (cancelled) return;
       try {
@@ -60,53 +63,132 @@ export default function ChatPage() {
         if (st === "completed") {
           let readyName = "";
           setAttachment((curr) => {
-            if (!curr || curr.documentId !== docId || curr.status !== "processing") return curr;
+            if (!curr || curr.documentId !== docId || curr.status !== "processing") {
+              return curr;
+            }
             readyName = curr.fileName;
             return { ...curr, status: "ready" };
           });
           if (readyName) {
-            setMessages((prev) => [...prev, { id: Date.now(), sender: "ai", text: `Document "${readyName}" is ready. You can ask questions about it.` }]);
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: Date.now(),
+                sender: "ai",
+                text: `Document "${readyName}" is ready. You can ask questions about it.`,
+              },
+            ]);
           }
         } else if (st === "failed") {
-          setAttachment((curr) => curr?.documentId === docId ? { ...curr, status: "failed" } : curr);
+          setAttachment((curr) =>
+            curr?.documentId === docId ? { ...curr, status: "failed" } : curr
+          );
         }
       } catch (e) {
         if (e instanceof DocumentNotFoundError) {
-          setAttachment((curr) => curr?.documentId === docId ? { ...curr, status: "failed" } : curr);
+          setAttachment((curr) =>
+            curr?.documentId === docId ? { ...curr, status: "failed" } : curr
+          );
           return;
         }
+        /* next interval */
       }
     };
+
     void poll();
     const interval = setInterval(poll, 2500);
-    return () => { cancelled = true; clearInterval(interval); };
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are the primitive values we react to, not the object ref
   }, [attachment?.documentId, attachment?.status]);
 
-  const isSendDisabled = !input.trim() || attachment?.status === "processing";
-
-  const handleSend = () => {
-    if (!input.trim()) return;
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || inflight) return;
     if (attachment?.status === "processing") return;
-    const document_id = attachment?.status === "ready" ? attachment.documentId : undefined;
-    setMessages((prev) => [...prev, { id: Date.now(), sender: "user", text: input.trim(), document_id }]);
+
     setInput("");
+
+    if (attachment?.status !== "ready") {
+      const base = Date.now();
+      setMessages((prev) => [
+        ...prev,
+        { id: base, sender: "user", text },
+        {
+          id: base + 1,
+          sender: "ai",
+          text: "Please upload a document first so I can answer questions about it.",
+        },
+      ]);
+      return;
+    }
+
+    const base = Date.now();
+    setMessages((prev) => [
+      ...prev,
+      { id: base, sender: "user", text, document_id: attachment.documentId },
+    ]);
+    setInflight(true);
+
+    try {
+      const response = await sendMessage(text, attachment.documentId);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: base + 1,
+          sender: "ai",
+          text: response.answer,
+          sources: response.sources,
+        },
+      ]);
+    } catch (e) {
+      let errorText = "Something went wrong. Please try again.";
+      if (e instanceof ChatError) {
+        errorText = e.message;
+        if (e.code === "no_document") {
+          setAttachment((curr) => (curr ? { ...curr, status: "failed" } : curr));
+        }
+      }
+      setMessages((prev) => [...prev, { id: base + 1, sender: "ai", text: errorText }]);
+    } finally {
+      setInflight(false);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") handleSend();
+    if (e.key === "Enter") void handleSend();
   };
 
   const handleBeforeUpload = async () => {
     if (!attachment) return;
     const out = await deleteDocument(attachment.documentId);
-    if (out === "gone") { setAttachment(null); setRemoveError(null); return; }
-    if (out === "conflict") throw new Error("Wait for the current document to finish processing, or remove it, before uploading another.");
+    if (out === "gone") {
+      setAttachment(null);
+      setRemoveError(null);
+      return;
+    }
+    if (out === "conflict") {
+      throw new Error(
+        "Wait for the current document to finish processing, or remove it, before uploading another."
+      );
+    }
     throw new Error("Could not remove the previous document. Try again.");
   };
 
-  const handleUploadAccepted = (payload: { fileName: string; documentId: string; statusEndpoint: string }) => {
+  const handleUploadAccepted = (payload: {
+    fileName: string;
+    documentId: string;
+    statusEndpoint: string;
+  }) => {
     setRemoveError(null);
-    setAttachment({ fileName: payload.fileName, documentId: payload.documentId, statusEndpoint: payload.statusEndpoint, status: "processing" });
+    setAttachment({
+      fileName: payload.fileName,
+      documentId: payload.documentId,
+      statusEndpoint: payload.statusEndpoint,
+      status: "processing",
+    });
   };
 
   const handleRemoveAttachment = async () => {
@@ -114,21 +196,46 @@ export default function ChatPage() {
     setRemoveError(null);
     try {
       const out = await deleteDocument(attachment.documentId);
-      if (out === "gone") { setAttachment(null); return; }
-      if (out === "conflict") { setRemoveError("Can't remove while the document is queued or processing."); return; }
+      if (out === "gone") {
+        setAttachment(null);
+        return;
+      }
+      if (out === "conflict") {
+        setRemoveError("Can't remove while the document is queued or processing.");
+        return;
+      }
       setRemoveError("Could not remove the document. Try again.");
-    } catch { setRemoveError("Could not remove the document. Try again."); }
+    } catch {
+      setRemoveError("Could not remove the document. Try again.");
+    }
   };
 
-  const chipLabel = attachment?.status === "processing" ? "Processing..." : attachment?.status === "failed" ? "Processing failed" : attachment?.fileName ?? "";
-  const sendTooltip = attachment?.status === "processing" ? "Document still processing..." : !input.trim() ? "Type a message to send" : undefined;
+  const chipLabel =
+    attachment?.status === "processing"
+      ? "Processing…"
+      : attachment?.status === "failed"
+        ? "Processing failed"
+        : attachment?.fileName ?? "";
+
+  const sendDisabled =
+    inflight || !input.trim() || attachment?.status === "processing";
 
   return (
     <div className="flex flex-col h-screen bg-gray-950 text-white">
-      {showModal && (<UploadModal onClose={() => setShowModal(false)} onBeforeUpload={handleBeforeUpload} onUploadAccepted={handleUploadAccepted} />)}
+      {showModal && (
+        <UploadModal
+          onClose={() => setShowModal(false)}
+          onBeforeUpload={handleBeforeUpload}
+          onUploadAccepted={handleUploadAccepted}
+        />
+      )}
+
       <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
         {messages.map((msg) => (
-          <div key={msg.id} className={`flex items-end gap-2 ${msg.sender === "user" ? "flex-row-reverse" : "flex-row"}`}>
+          <div
+            key={msg.id}
+            className={`flex items-end gap-2 ${msg.sender === "user" ? "flex-row-reverse" : "flex-row"}`}
+          >
             <div className={`w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center ${msg.sender === "ai" ? "bg-indigo-600" : "bg-gray-600"}`}>
               {msg.sender === "ai" ? <Bot size={16} /> : <User size={16} />}
             </div>
@@ -149,30 +256,91 @@ export default function ChatPage() {
         )}
         <div ref={bottomRef} />
       </div>
+
       {attachment && (
         <div className="px-4 py-2 bg-gray-900 border-t border-gray-800 flex items-center gap-2">
-          <FileText size={14} className={attachment.status === "failed" ? "text-red-400" : attachment.status === "processing" ? "text-amber-400" : "text-indigo-400"} />
+          <FileText
+            size={14}
+            className={
+              attachment.status === "failed"
+                ? "text-red-400"
+                : attachment.status === "processing"
+                  ? "text-amber-400"
+                  : "text-indigo-400"
+            }
+          />
           <span className="text-xs text-gray-400">Active document:</span>
-          <span className={`text-xs font-medium flex-1 truncate ${attachment.status === "failed" ? "text-red-400" : attachment.status === "processing" ? "text-amber-400" : "text-indigo-400"}`}>{chipLabel}</span>
-          <button type="button" onClick={handleRemoveAttachment} className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-gray-800 transition shrink-0" aria-label="Remove attachment"><X size={16} /></button>
+          <span
+            className={`text-xs font-medium flex-1 truncate ${
+              attachment.status === "failed"
+                ? "text-red-400"
+                : attachment.status === "processing"
+                  ? "text-amber-400"
+                  : "text-indigo-400"
+            }`}
+          >
+            {chipLabel}
+          </span>
+          <button
+            type="button"
+            onClick={handleRemoveAttachment}
+            className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-gray-800 transition shrink-0"
+            aria-label="Remove attachment"
+          >
+            <X size={16} />
+          </button>
         </div>
       )}
       {attachment?.status === "processing" && (
-        <p className="px-4 pb-1 text-xs text-amber-400 bg-gray-900">Document still processing - sending is disabled until it is ready.</p>
+        <p className="px-4 pb-1 text-xs text-amber-400 bg-gray-900">
+          Document still processing — sending is disabled until it is ready.
+        </p>
       )}
-      {removeError && (<p className="px-4 pb-1 text-xs text-red-400 bg-gray-900">{removeError}</p>)}
+      {removeError && (
+        <p className="px-4 pb-1 text-xs text-red-400 bg-gray-900">{removeError}</p>
+      )}
+
       <div className="px-4 py-3 border-t border-gray-800 bg-gray-900">
         <div className="flex items-center gap-2 bg-gray-800 rounded-xl px-4 py-2">
           <UploadButton onClick={() => setShowModal(true)} />
-          <input type="text" value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={handleKeyDown}
-            placeholder={attachment?.status === "processing" ? "Waiting for document to be ready..." : "Ask about your document..."}
-            className="flex-1 bg-transparent outline-none text-sm text-white placeholder-gray-500" />
-          <button onClick={handleSend} disabled={isSendDisabled} title={sendTooltip}
-            className={`w-8 h-8 rounded-lg flex items-center justify-center transition ${isSendDisabled ? "bg-gray-600 cursor-not-allowed opacity-50" : "bg-indigo-600 hover:bg-indigo-500 cursor-pointer"}`}>
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={
+              attachment?.status === "processing"
+                ? "Waiting for document to be ready..."
+                : "Ask about your document..."
+            }
+            disabled={inflight}
+            className="flex-1 bg-transparent outline-none text-sm text-white placeholder-gray-500 disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={() => void handleSend()}
+            disabled={sendDisabled}
+            title={
+              inflight
+                ? "Waiting for response..."
+                : attachment?.status === "processing"
+                  ? "Document still processing..."
+                  : !input.trim()
+                    ? "Type a message to send"
+                    : undefined
+            }
+            className={`w-8 h-8 rounded-lg flex items-center justify-center transition ${
+              sendDisabled
+                ? "bg-gray-600 cursor-not-allowed opacity-50"
+                : "bg-indigo-600 hover:bg-indigo-500 cursor-pointer"
+            }`}
+          >
             <Send size={15} />
           </button>
         </div>
-        <p className="text-center text-xs text-gray-600 mt-2">ChatVector may make mistakes. Always verify important information.</p>
+        <p className="text-center text-xs text-gray-600 mt-2">
+          ChatVector may make mistakes. Always verify important information.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Restores the chat UI behavior from `feat/connect-chat-to-backend` after a bad merge left `welcomeMessages` undefined and dropped backend wiring.

## Changes
- Single `welcomeMessages` welcome line; `sendMessage` + `ChatError` handling including `no_document` → mark attachment failed
- Document status polling with primitive effect deps and documented eslint exception
- Do not clear input or show “upload first” while a document is still **processing**; disable send and show processing hints
- Stable message IDs per send; `void handleSend` for async handlers

## Test plan
- [ ] `npm run build` in `frontend-demo`
- [ ] Upload → poll → chat with ready document; try send with no doc / processing / ready
