### PR TITLE
fix(status): cache health checks for status endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,9 @@ POSTGRES_DB=postgres
 # ── Background ingestion queue ────────────────────────────────────────────
 # QUEUE_RETRY_BASE_DELAY=2.0  # base seconds for queue job retry backoff
 
+# Status health checks
+HEALTH_CHECK_CACHE_TTL_SECONDS=60
+
 # ── SQLAlchemy / PostgreSQL ───────────────────────────────────────────────
 # SQLALCHEMY_STATEMENT_TIMEOUT_SEC=30
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -94,6 +94,9 @@ class Settings:
     QUEUE_RETRY_BASE_DELAY: float = max(
         0.1, float(os.getenv("QUEUE_RETRY_BASE_DELAY", "2.0"))
     )
+    HEALTH_CHECK_CACHE_TTL_SECONDS: int = max(
+        0, int(os.getenv("HEALTH_CHECK_CACHE_TTL_SECONDS", "60"))
+    )
 
     RATE_LIMIT_UPLOAD: str = os.getenv("RATE_LIMIT_UPLOAD", "20/hour")
     RATE_LIMIT_CHAT: str = os.getenv("RATE_LIMIT_CHAT", "30/minute")

--- a/backend/routes/status.py
+++ b/backend/routes/status.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,9 +16,6 @@ from sqlalchemy.exc import SQLAlchemyError
 import db
 from core.config import config
 from middleware.rate_limit import limiter
-from core.models import Document as DocumentModel
-from db.sqlalchemy_service import SQLAlchemyService
-from db.supabase_service import SupabaseService
 from routes.root import _is_browser
 from services.queue_service import ingestion_queue
 
@@ -26,6 +25,8 @@ router = APIRouter()
 
 BACKEND_ROOT = Path(__file__).resolve().parent.parent
 _BAR_WIDTH = 10
+_HEALTH_CHECK_CACHE: dict[str, dict[str, Any]] = {}
+_HEALTH_CHECK_CACHE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 def _read_version() -> str:
@@ -78,7 +79,11 @@ def _workers_active_count() -> int:
 
 async def _database_connected_and_document_count() -> tuple[bool, int | None]:
     service = db.get_db_service()
+    from db.sqlalchemy_service import SQLAlchemyService
+
     if isinstance(service, SQLAlchemyService):
+        from core.models import Document as DocumentModel
+
         try:
             async with service.async_session() as session:
                 await session.execute(text("SELECT 1"))
@@ -90,6 +95,8 @@ async def _database_connected_and_document_count() -> tuple[bool, int | None]:
         except Exception:
             logger.exception("Unexpected error during database health check")
             return False, None
+
+    from db.supabase_service import SupabaseService
 
     if isinstance(service, SupabaseService):
 
@@ -125,6 +132,81 @@ async def _database_connected_and_document_count() -> tuple[bool, int | None]:
 def _short_error_message(exc: BaseException, max_len: int = 120) -> str:
     msg = str(exc).strip() or type(exc).__name__
     return msg[:max_len]
+
+
+def _health_check_checked_at(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _health_check_response(
+    result: dict[str, Any],
+    *,
+    cached: bool,
+    checked_at: str,
+) -> dict[str, Any]:
+    response = dict(result)
+    response["cached"] = cached
+    response["checked_at"] = checked_at
+    return response
+
+
+def _health_check_cache_is_fresh(entry: dict[str, Any], now_monotonic: float) -> bool:
+    checked_monotonic = entry.get("checked_monotonic")
+    if not isinstance(checked_monotonic, (int, float)):
+        return False
+    return now_monotonic - float(checked_monotonic) < config.HEALTH_CHECK_CACHE_TTL_SECONDS
+
+
+def _health_check_cache_hit(check_name: str, now_monotonic: float) -> dict[str, Any] | None:
+    entry = _HEALTH_CHECK_CACHE.get(check_name)
+    if not entry or not _health_check_cache_is_fresh(entry, now_monotonic):
+        return None
+
+    cached_result = entry.get("result")
+    checked_at = entry.get("checked_at")
+    if not isinstance(cached_result, dict) or not isinstance(checked_at, str):
+        return None
+
+    return _health_check_response(cached_result, cached=True, checked_at=checked_at)
+
+
+def _health_check_lock(check_name: str) -> asyncio.Lock:
+    lock = _HEALTH_CHECK_CACHE_LOCKS.get(check_name)
+    if lock is None:
+        lock = asyncio.Lock()
+        _HEALTH_CHECK_CACHE_LOCKS[check_name] = lock
+    return lock
+
+
+async def _run_health_check_with_cache(
+    check_name: str,
+    health_check: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    ttl_seconds = config.HEALTH_CHECK_CACHE_TTL_SECONDS
+    if ttl_seconds <= 0:
+        result = await health_check()
+        checked_at = _health_check_checked_at(time.time())
+        return _health_check_response(result, cached=False, checked_at=checked_at)
+
+    now_monotonic = time.monotonic()
+    cached_result = _health_check_cache_hit(check_name, now_monotonic)
+    if cached_result is not None:
+        return cached_result
+
+    async with _health_check_lock(check_name):
+        now_monotonic = time.monotonic()
+        cached_result = _health_check_cache_hit(check_name, now_monotonic)
+        if cached_result is not None:
+            return cached_result
+
+        result = await health_check()
+        checked_at = _health_check_checked_at(time.time())
+        _HEALTH_CHECK_CACHE[check_name] = {
+            "result": dict(result),
+            "checked_at": checked_at,
+            "checked_monotonic": now_monotonic,
+        }
+        return _health_check_response(result, cached=False, checked_at=checked_at)
 
 
 async def _embedding_health_check() -> dict:
@@ -330,8 +412,8 @@ async def status(request: Request):
     start = getattr(request.app.state, "start_time", time.time())
     db_result, embedding_result, llm_result = await asyncio.gather(
         _database_connected_and_document_count(),
-        _embedding_health_check(),
-        _llm_health_check(),
+        _run_health_check_with_cache("embedding", _embedding_health_check),
+        _run_health_check_with_cache("llm", _llm_health_check),
         return_exceptions=True,
     )
 

--- a/backend/tests/test_status.py
+++ b/backend/tests/test_status.py
@@ -3,12 +3,39 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import routes.status as status_module
 
 from routes.status import (
     _embedding_health_check,
     _llm_health_check,
     _overall_status,
+    _run_health_check_with_cache,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_health_check_cache():
+    status_module._HEALTH_CHECK_CACHE.clear()
+    status_module._HEALTH_CHECK_CACHE_LOCKS.clear()
+    yield
+    status_module._HEALTH_CHECK_CACHE.clear()
+    status_module._HEALTH_CHECK_CACHE_LOCKS.clear()
+
+
+class _FakeClock:
+    def __init__(self, *, monotonic: float = 1000.0, wall: float = 1704067200.0):
+        self.monotonic_value = monotonic
+        self.wall_value = wall
+
+    def advance(self, seconds: float) -> None:
+        self.monotonic_value += seconds
+        self.wall_value += seconds
+
+    def monotonic(self) -> float:
+        return self.monotonic_value
+
+    def time(self) -> float:
+        return self.wall_value
 
 
 @pytest.mark.asyncio
@@ -59,6 +86,86 @@ async def test_llm_health_check_error_when_generate_answer_raises():
 
     assert result["status"] == "error"
     assert result["error"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_run_health_check_with_cache_reuses_result_within_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(status_module.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(status_module.time, "time", clock.time)
+    monkeypatch.setattr(status_module.config, "HEALTH_CHECK_CACHE_TTL_SECONDS", 60)
+    health_check = AsyncMock(
+        side_effect=[
+            {"status": "ok", "latency_ms": 17},
+            {"status": "ok", "latency_ms": 99},
+        ]
+    )
+
+    first = await _run_health_check_with_cache("embedding", health_check)
+    clock.advance(30)
+    second = await _run_health_check_with_cache("embedding", health_check)
+
+    assert first["cached"] is False
+    assert second["cached"] is True
+    assert second["latency_ms"] == 17
+    assert first["checked_at"] == second["checked_at"]
+    assert second["checked_at"].endswith("Z")
+    health_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_health_check_with_cache_refreshes_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(status_module.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(status_module.time, "time", clock.time)
+    monkeypatch.setattr(status_module.config, "HEALTH_CHECK_CACHE_TTL_SECONDS", 60)
+    health_check = AsyncMock(
+        side_effect=[
+            {"status": "ok", "latency_ms": 11},
+            {"status": "ok", "latency_ms": 29},
+        ]
+    )
+
+    first = await _run_health_check_with_cache("embedding", health_check)
+    clock.advance(61)
+    second = await _run_health_check_with_cache("embedding", health_check)
+
+    assert first["cached"] is False
+    assert second["cached"] is False
+    assert second["latency_ms"] == 29
+    assert second["checked_at"] != first["checked_at"]
+    assert health_check.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_health_check_with_cache_tracks_embedding_and_llm_independently(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(status_module.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(status_module.time, "time", clock.time)
+    monkeypatch.setattr(status_module.config, "HEALTH_CHECK_CACHE_TTL_SECONDS", 60)
+    embedding_check = AsyncMock(
+        side_effect=[
+            {"status": "ok", "latency_ms": 12},
+            {"status": "ok", "latency_ms": 44},
+        ]
+    )
+    llm_check = AsyncMock(return_value={"status": "error", "error": "timeout"})
+
+    first_embedding = await _run_health_check_with_cache("embedding", embedding_check)
+    clock.advance(30)
+    first_llm = await _run_health_check_with_cache("llm", llm_check)
+    clock.advance(40)
+    second_embedding = await _run_health_check_with_cache("embedding", embedding_check)
+    second_llm = await _run_health_check_with_cache("llm", llm_check)
+
+    assert first_embedding["cached"] is False
+    assert first_llm["cached"] is False
+    assert second_embedding["cached"] is False
+    assert second_embedding["latency_ms"] == 44
+    assert second_llm["cached"] is True
+    assert second_llm["error"] == "timeout"
+    assert embedding_check.await_count == 2
+    llm_check.assert_awaited_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# PR Title
fix(status): cache embedding and LLM health checks in /status (closes #159)

# PR Description
## Summary
This PR reduces avoidable Gemini usage on the `/status` endpoint by adding a small in-memory TTL cache for the embedding and LLM health checks. Database health checks remain live on every request.

## What was happening
- `/status` made fresh embedding and LLM API calls on every request.
- Frequent polling from monitors could burn API quota and add unnecessary latency.
- Operators could not tell whether a health-check result was live or recently reused.

## What changed
- Added `HEALTH_CHECK_CACHE_TTL_SECONDS` to backend config with a default of `60`.
- Updated `backend/.env.example` with the new cache TTL setting.
- Added separate module-level cache entries for `embedding` and `llm` health checks in `backend/routes/status.py`.
- Cached both successful and failing health-check results independently, so each check refreshes on its own TTL boundary.
- Added `cached` and `checked_at` fields to each embedding and LLM health-check payload.
- Added a small per-check async lock so concurrent requests do not fan out duplicate live health checks on a cold or expired cache.
- Moved status-route DB-specific imports into the database health-check function so the module avoids unnecessary import-time DB initialization.

## Why this fix works
- Polling inside the TTL window now reuses the most recent embedding/LLM result instead of issuing new Gemini calls.
- Each health check has its own cache key, so one can refresh while the other is still served from cache.
- Failing checks are not hidden forever; they are retried once their TTL expires.
- `checked_at` shows when the last live check happened, and `cached` tells operators whether the current value came from cache.

## Test coverage
- Added targeted cache-behavior tests for:
  - reuse within TTL
  - refresh after TTL expiry
  - independent embedding vs LLM cache windows
- Verified with:
  - `pytest -q backend/tests/test_status.py`

## Impact
- Reduces unnecessary external API traffic from `/status` polling.
- Improves endpoint responsiveness for repeated health checks.
- Preserves current DB health-check behavior and existing status semantics.