### PR TITLE
fix(devx): bundle psycopg binary for local tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -310,13 +310,19 @@ pytest --cov=app # coverage
 
 ### Running Locally
 
+`backend/requirements.txt` installs `psycopg[binary]`, so local pytest
+collection does not require a separate system `libpq` installation. If you
+already have an older local environment, reinstall the backend requirements so
+`psycopg` and `psycopg-binary` stay on matching versions.
+
 ```bash
 cd backend
 pip install -r requirements.txt
 pytest tests/ -v
 ```
 
-(PostgreSQL must be running.)
+The bundled binary wheel removes the extra `libpq` setup step, but tests that
+open real PostgreSQL connections still need a running Postgres instance.
 
 ---
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ tenacity==9.1.2
 
 # -------- Database / Vector --------
 SQLAlchemy[asyncio]==2.0.36
-psycopg==3.3.2
+psycopg[binary]==3.3.2
 pgvector==0.4.2
 asyncpg
 postgrest==2.24.0


### PR DESCRIPTION
# PR Title
fix(devx): bundle psycopg binary for local backend tests (closes #172)

# PR Description
## Summary
This PR removes a common local test bootstrap failure by switching the backend dependency pin from `psycopg` to `psycopg[binary]` and documenting the intended local pytest workflow in `DEVELOPMENT.md`.

## What was happening
- Local pytest collection could fail before any real test logic ran because importing the DB layer pulled in `psycopg`.
- On contributor machines without a usable `libpq` setup, or with mismatched `psycopg` / `psycopg-binary` installs, DB-adjacent tests failed even when they only mocked the database.
- This created unnecessary friction for contributors who just wanted to run backend tests locally.

## What changed
- Updated `backend/requirements.txt` to install `psycopg[binary]==3.3.2`.
- Updated `DEVELOPMENT.md` to explain that local pytest collection no longer needs a separate system `libpq` install.
- Documented that contributors with older environments should reinstall backend requirements so `psycopg` and `psycopg-binary` stay on matching versions.
- Clarified that tests opening real PostgreSQL connections still need a running Postgres instance.

## Why this fix works
- The `binary` extra installs the matching `psycopg-binary` wheel alongside the pinned `psycopg` version, which bundles the native client dependency instead of relying on a separately installed system `libpq`.
- Keeping the core package and binary wheel on the same pinned version avoids the broken mixed-version state that can surface as import-time failures.
- This improves the default local contributor experience without changing CI or Docker behavior.

## Test coverage
- Verified the raw driver import works after installing the matching binary wheel:
  - `python -c "import psycopg; print(psycopg.__version__)"`
- Verified previously failing DB-import-heavy unit tests run locally after the fix:
  - `pytest -q backend/tests/test_factory.py backend/tests/test_status.py`

## Impact
- Reduces local setup friction for backend contributors.
- Makes unit-style backend tests more likely to run on a fresh machine without Docker.
- Leaves existing Docker and real-Postgres workflows unchanged.