### PR TITLE
refactor(frontend-demo): document polling hook and attachment chip

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Send, Bot, User, FileText, X } from "lucide-react";
+import { Send, Bot, User } from "lucide-react";
 import UploadButton from "../components/UploadButton";
 import UploadModal from "../components/UploadModal";
+import AttachmentChip from "../components/AttachmentChip";
 import {
   deleteDocument,
-  DocumentNotFoundError,
-  getDocumentStatus,
   sendMessage,
   ChatError,
+  type AttachmentState,
+  type ChatSource,
 } from "../lib/api";
-import type { ChatSource } from "../lib/api";
+import { useDocumentPolling } from "../lib/hooks/useDocumentPolling";
 
 type Message = {
   id: number;
@@ -19,13 +20,6 @@ type Message = {
   text: string;
   document_id?: string;
   sources?: ChatSource[];
-};
-
-type AttachmentState = {
-  fileName: string;
-  documentId: string;
-  statusEndpoint: string;
-  status: "processing" | "ready" | "failed";
 };
 
 const welcomeMessages: Message[] = [
@@ -44,65 +38,68 @@ export default function ChatPage() {
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [inflight, setInflight] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const readyAnnouncedForDocRef = useRef<string | null>(null);
+
+  const poll = useDocumentPolling(
+    attachment?.documentId,
+    attachment?.statusEndpoint,
+    attachment?.status
+  );
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, inflight]);
 
   useEffect(() => {
-    if (!attachment || attachment.status !== "processing") return;
+    if (poll.status === "ready") {
+      setShowModal(false);
+    }
+  }, [poll.status]);
 
+  useEffect(() => {
+    readyAnnouncedForDocRef.current = null;
+  }, [attachment?.documentId]);
+
+  useEffect(() => {
+    if (poll.status !== "ready" || !attachment || attachment.status !== "processing") {
+      return;
+    }
     const docId = attachment.documentId;
-    const statusPath = attachment.statusEndpoint;
-    let cancelled = false;
-
-    const poll = async () => {
-      if (cancelled) return;
-      try {
-        const { status: st } = await getDocumentStatus(statusPath);
-        if (st === "completed") {
-          let readyName = "";
-          setAttachment((curr) => {
-            if (!curr || curr.documentId !== docId || curr.status !== "processing") {
-              return curr;
-            }
-            readyName = curr.fileName;
-            return { ...curr, status: "ready" };
-          });
-          if (readyName) {
-            setMessages((prev) => [
-              ...prev,
-              {
-                id: Date.now(),
-                sender: "ai",
-                text: `Document "${readyName}" is ready. You can ask questions about it.`,
-              },
-            ]);
-          }
-        } else if (st === "failed") {
-          setAttachment((curr) =>
-            curr?.documentId === docId ? { ...curr, status: "failed" } : curr
-          );
-        }
-      } catch (e) {
-        if (e instanceof DocumentNotFoundError) {
-          setAttachment((curr) =>
-            curr?.documentId === docId ? { ...curr, status: "failed" } : curr
-          );
-          return;
-        }
-        /* next interval */
+    if (readyAnnouncedForDocRef.current === docId) {
+      return;
+    }
+    readyAnnouncedForDocRef.current = docId;
+    const name = attachment.fileName;
+    setAttachment((curr) => {
+      if (!curr || curr.documentId !== docId || curr.status !== "processing") {
+        return curr;
       }
-    };
+      return {
+        ...curr,
+        status: "ready",
+        stage: "completed",
+        chunks: poll.chunks,
+      };
+    });
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        sender: "ai",
+        text: `Document "${name}" is ready. You can ask questions about it.`,
+      },
+    ]);
+  }, [poll.status, poll.chunks, attachment]);
 
-    void poll();
-    const interval = setInterval(poll, 2500);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are the primitive values we react to, not the object ref
-  }, [attachment?.documentId, attachment?.status]);
+  useEffect(() => {
+    if (poll.status !== "failed" || !attachment || attachment.status !== "processing") {
+      return;
+    }
+    const docId = attachment.documentId;
+    setAttachment((curr) =>
+      curr?.documentId === docId ? { ...curr, status: "failed" } : curr
+    );
+  }, [poll.status, attachment]);
 
   const handleSend = async () => {
     const text = input.trim();
@@ -210,13 +207,6 @@ export default function ChatPage() {
     }
   };
 
-  const chipLabel =
-    attachment?.status === "processing"
-      ? "Processing…"
-      : attachment?.status === "failed"
-        ? "Processing failed"
-        : attachment?.fileName ?? "";
-
   const sendDisabled =
     inflight || !input.trim() || attachment?.status === "processing";
 
@@ -258,38 +248,14 @@ export default function ChatPage() {
       </div>
 
       {attachment && (
-        <div className="px-4 py-2 bg-gray-900 border-t border-gray-800 flex items-center gap-2">
-          <FileText
-            size={14}
-            className={
-              attachment.status === "failed"
-                ? "text-red-400"
-                : attachment.status === "processing"
-                  ? "text-amber-400"
-                  : "text-indigo-400"
-            }
-          />
-          <span className="text-xs text-gray-400">Active document:</span>
-          <span
-            className={`text-xs font-medium flex-1 truncate ${
-              attachment.status === "failed"
-                ? "text-red-400"
-                : attachment.status === "processing"
-                  ? "text-amber-400"
-                  : "text-indigo-400"
-            }`}
-          >
-            {chipLabel}
-          </span>
-          <button
-            type="button"
-            onClick={handleRemoveAttachment}
-            className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-gray-800 transition shrink-0"
-            aria-label="Remove attachment"
-          >
-            <X size={16} />
-          </button>
-        </div>
+        <AttachmentChip
+          fileName={attachment.fileName}
+          status={attachment.status}
+          stage={poll.stage}
+          chunks={poll.chunks}
+          awaitingProcessing={poll.awaitingProcessing}
+          onRemove={() => void handleRemoveAttachment()}
+        />
       )}
       {attachment?.status === "processing" && (
         <p className="px-4 pb-1 text-xs text-amber-400 bg-gray-900">

--- a/frontend-demo/app/components/AttachmentChip.tsx
+++ b/frontend-demo/app/components/AttachmentChip.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { FileText, X } from "lucide-react";
+
+const STAGE_LABELS: Record<string, string> = {
+  queued: "Queued…",
+  uploaded: "Uploaded…",
+  extracting: "Extracting text…",
+  chunking: "Chunking…",
+  embedding: "Embedding…",
+  storing: "Storing…",
+  completed: "Ready",
+  failed: "Failed",
+};
+
+type Props = {
+  fileName: string;
+  status: "processing" | "ready" | "failed";
+  stage?: string;
+  chunks?: { total: number; processed: number };
+  awaitingProcessing?: boolean;
+  onRemove: () => void;
+};
+
+function chipLabel(
+  fileName: string,
+  status: Props["status"],
+  stage: string | undefined,
+  chunks: Props["chunks"],
+  awaitingProcessing: boolean
+): string {
+  if (status === "ready") {
+    return fileName;
+  }
+  if (status === "failed") {
+    return STAGE_LABELS.failed;
+  }
+  if (awaitingProcessing && !stage) {
+    return "Processing…";
+  }
+  const base =
+    (stage && STAGE_LABELS[stage]) ||
+    (stage ? stage : "Processing…");
+  if (
+    stage === "embedding" &&
+    chunks != null &&
+    typeof chunks.total === "number" &&
+    chunks.total > 0
+  ) {
+    return `${STAGE_LABELS.embedding} (${chunks.total} chunks)`;
+  }
+  return base;
+}
+
+function iconAndTextClass(status: Props["status"]): string {
+  if (status === "failed") return "text-red-400";
+  if (status === "processing") return "text-amber-400";
+  return "text-indigo-400";
+}
+
+export default function AttachmentChip({
+  fileName,
+  status,
+  stage,
+  chunks,
+  awaitingProcessing = false,
+  onRemove,
+}: Props) {
+  const label = chipLabel(
+    fileName,
+    status,
+    stage,
+    chunks,
+    awaitingProcessing
+  );
+  const tone = iconAndTextClass(status);
+
+  return (
+    <div className="px-4 py-2 bg-gray-900 border-t border-gray-800 flex items-center gap-2">
+      <FileText size={14} className={tone} />
+      <span className="text-xs text-gray-400">Active document:</span>
+      <span
+        className={`text-xs font-medium flex-1 truncate ${tone}`}
+      >
+        {label}
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-gray-800 transition shrink-0"
+        aria-label="Remove attachment"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -76,14 +76,47 @@ export class DocumentNotFoundError extends Error {
   }
 }
 
+export type AttachmentState = {
+  fileName: string;
+  documentId: string;
+  statusEndpoint: string;
+  status: "processing" | "ready" | "failed";
+  stage?: string;
+  chunks?: { total: number; processed: number };
+};
+
+export type DocumentStatusPayload = {
+  status: string;
+  stage?: string;
+  chunks?: { total: number; processed: number } | null;
+};
+
+function parseChunks(raw: unknown): { total: number; processed: number } | undefined {
+  if (raw == null || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  const total = o.total;
+  const processed = o.processed;
+  if (typeof total !== "number" || typeof processed !== "number") return undefined;
+  return { total, processed };
+}
+
 export async function getDocumentStatus(
   statusEndpoint: string
-): Promise<{ status: string }> {
+): Promise<DocumentStatusPayload> {
   const res = await fetch(`${API_BASE}${statusEndpoint}`);
   if (res.status === 404) throw new DocumentNotFoundError();
   if (!res.ok) throw new Error(`Status check failed: ${res.status}`);
-  const data = await res.json();
-  return { status: String(data?.status ?? "") };
+  const data = (await res.json()) as Record<string, unknown>;
+  const status = String(data?.status ?? "");
+  const stageRaw = data?.stage;
+  const stage =
+    typeof stageRaw === "string" && stageRaw.length > 0 ? stageRaw : undefined;
+  const chunks = parseChunks(data?.chunks);
+  return {
+    status,
+    ...(stage !== undefined ? { stage } : {}),
+    ...(chunks !== undefined ? { chunks } : {}),
+  };
 }
 
 export async function uploadDocument(

--- a/frontend-demo/app/lib/hooks/useDocumentPolling.ts
+++ b/frontend-demo/app/lib/hooks/useDocumentPolling.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  DocumentNotFoundError,
+  getDocumentStatus,
+} from "../api";
+
+export type PolledDocumentStatus = "processing" | "ready" | "failed";
+
+function mapApiStatusToUi(apiStatus: string): PolledDocumentStatus {
+  if (apiStatus === "completed") return "ready";
+  if (apiStatus === "failed") return "failed";
+  return "processing";
+}
+
+export function useDocumentPolling(
+  documentId: string | undefined,
+  statusEndpoint: string | undefined,
+  status: PolledDocumentStatus | undefined
+): {
+  status: PolledDocumentStatus | undefined;
+  stage: string | undefined;
+  chunks: { total: number; processed: number } | undefined;
+  awaitingProcessing: boolean;
+} {
+  const [polledUiStatus, setPolledUiStatus] = useState<
+    PolledDocumentStatus | undefined
+  >(undefined);
+  const [stage, setStage] = useState<string | undefined>(undefined);
+  const [chunks, setChunks] = useState<
+    { total: number; processed: number } | undefined
+  >(undefined);
+  const [awaitingProcessing, setAwaitingProcessing] = useState(false);
+
+  const enabled =
+    Boolean(documentId && statusEndpoint) && status === "processing";
+
+  const docKey = documentId ?? "";
+  const prevDocKeyRef = useRef<string>("");
+
+  useEffect(() => {
+    if (docKey !== prevDocKeyRef.current) {
+      prevDocKeyRef.current = docKey;
+      setPolledUiStatus(undefined);
+      setStage(undefined);
+      setChunks(undefined);
+      setAwaitingProcessing(false);
+    }
+  }, [docKey]);
+
+  useEffect(() => {
+    if (!enabled || !documentId || !statusEndpoint) {
+      return;
+    }
+
+    setAwaitingProcessing(true);
+
+    let cancelled = false;
+    const docId = documentId;
+    const path = statusEndpoint;
+
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const payload = await getDocumentStatus(path);
+        if (cancelled) return;
+
+        setAwaitingProcessing(false);
+
+        const rawStage =
+          typeof payload.stage === "string" && payload.stage.length > 0
+            ? payload.stage
+            : payload.status;
+        setStage(rawStage);
+
+        const c = payload.chunks;
+        if (
+          c &&
+          typeof c.total === "number" &&
+          typeof c.processed === "number"
+        ) {
+          setChunks({ total: c.total, processed: c.processed });
+        } else {
+          setChunks(undefined);
+        }
+
+        const ui = mapApiStatusToUi(payload.status);
+        setPolledUiStatus(ui);
+      } catch (e) {
+        if (e instanceof DocumentNotFoundError) {
+          if (cancelled) return;
+          setAwaitingProcessing(false);
+          setPolledUiStatus("failed");
+          return;
+        }
+        /* next interval */
+      }
+    };
+
+    void poll();
+    const interval = setInterval(poll, 2500);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [enabled, documentId, statusEndpoint]);
+
+  return {
+    status: polledUiStatus,
+    stage,
+    chunks,
+    awaitingProcessing: enabled && awaitingProcessing,
+  };
+}


### PR DESCRIPTION
This PR refactors the chat page document polling and attachment UI.

## Changes
- Extract polling into `useDocumentPolling` (same 2.5s interval); hook owns `awaitingProcessing` until the first successful status response.
- `getDocumentStatus` returns the full payload (`status`, optional `stage`, `chunks`); `AttachmentState` extended accordingly.
- New `AttachmentChip` with pipeline stage labels and embedding chunk count when `chunks.total` is available.
- Modal closes when polled status becomes `ready` via a page `useEffect`, not inside the polling logic.
- Send button behavior and disabled rules are unchanged.

## Files
- `frontend-demo/app/lib/hooks/useDocumentPolling.ts` (new)
- `frontend-demo/app/components/AttachmentChip.tsx` (new)
- `frontend-demo/app/lib/api.ts`
- `frontend-demo/app/chat/page.tsx`