### PR TITLE
refactor(frontend-demo): design tokens, Tailwind, and docs

### DIFF
--- a/frontend-demo/FRONTEND.md
+++ b/frontend-demo/FRONTEND.md
@@ -20,30 +20,33 @@ Semantic tokens live in `app/globals.css` under `:root`. They are the single sou
 
 ## Font stack
 
-- **DM Sans** — body copy, headings, and UI text. The root layout uses it for the main page wrapper (`font-[family-name:DM_Sans,sans-serif]` on the homepage container; `globals.css` sets `body` to DM Sans).
-- **JetBrains Mono** — monospace accents: section kicker lines (`// …`), filenames on code windows, tags/badges, and the wordmark-style logo treatment. Applied via `font-[family-name:JetBrains_Mono,monospace]` where needed.
+- **DM Sans** — body copy, headings, and UI text. `globals.css` sets `--font-sans` in `@theme inline` and applies `font-family: var(--font-sans)` on `body`.
+- **JetBrains Mono** — monospace accents: section kickers, code windows, tags, logo. `--font-mono` is set in `@theme inline`; use Tailwind `font-mono` (or `font-sans` for body text).
+
+`app/layout.tsx` still loads Geist via `next/font` for CSS variables on `body`, but those variables are no longer referenced by `@theme`; you can remove Geist to avoid downloading unused fonts.
 
 ## Spacing and layout conventions
 
 - **Content width:** Main column is `max-w-[1100px]` with horizontal padding `px-8` (`2rem`) on sections; the nav uses `max-w-[1100px]` and `px-4` (`1rem`) to match the previous navbar gutters.
 - **Vertical rhythm:** Major sections use `py-24` (`6rem`). The hero uses `pt-20` / `pb-16` / `px-8` to preserve the original top-heavy landing spacing.
 - **Grids:** Two-column blocks use `grid` with `gap-12` and `md:grid-cols-2`. Feature cards use `grid-cols-[repeat(auto-fit,minmax(240px,1fr))]` with `gap-6`.
-- **Cards:** Code samples and pipeline panels use `rounded-xl` (`12px`), `border border-(--border)`, and `p-6` or inner `py-3.5` / `px-6` as before.
+- **Cards:** Code samples and pipeline panels use `rounded-xl` (`12px`), `border border-border`, and `p-6` or inner `py-3.5` / `px-6` as before.
 
 ## Component patterns
 
-- **Section header:** Kicker (`// label`) in JetBrains Mono, `text-[0.78rem]`, `uppercase`, `tracking-[2px]`, `text-(--accent)`; title `text-[clamp(...)]`, `font-semibold`, `text-(--foreground)`; supporting copy `text-(--muted)` with `font-light` where the original used weight 300.
-- **Primary CTA:** Filled `bg-(--accent)`, `text-black`, `rounded-lg`, `px-7 py-3`, hover lift via `hover:-translate-y-0.5` and shadow.
-- **Secondary CTA:** `border border-(--border)`, transparent background, `hover:border-[rgb(61,69,85)]`, `hover:bg-(--surface)` (hover border is a fixed RGB lift, not a token).
-- **Code window:** Surface background, border, title bar `bg-[rgb(24,28,34)]`, traffic-light dots, filename in mono + `text-(--muted)`.
-- **Feature card:** The features section uses `bg-(--surface)`; each card uses `bg-(--background)`, `border-(--border)`, hover `border-[rgb(61,69,85)]` and `-translate-y-[3px]`. Tag pill uses `color-mix` with `var(--blue)` for fill and stroke.
-- **Developer checklist row:** `bg-(--surface)`, full border + `border-l-[3px] border-l-(--accent)`, check icon `text-(--accent)` / `stroke="currentColor"`.
+- **Section header:** Kicker (`// label`) in `font-mono`, `text-[0.78rem]`, `uppercase`, `tracking-[2px]`, `text-accent`; title `text-[clamp(...)]`, `font-semibold`, `text-foreground`; supporting copy `text-muted` with `font-light` where the original used weight 300.
+- **Primary CTA:** Filled `bg-accent`, `text-black`, `rounded-lg`, `px-7 py-3`, hover lift via `hover:-translate-y-0.5` and shadow.
+- **Secondary CTA:** `border border-border`, transparent background, `hover:border-[rgb(61,69,85)]`, `hover:bg-surface` (hover border is a fixed RGB lift, not a token).
+- **Code window:** Surface background, border, title bar `bg-[rgb(24,28,34)]`, traffic-light dots, filename in `font-mono` + `text-muted`.
+- **Feature card:** The features section uses `bg-surface`; each card uses `bg-background`, `border-border`, group hover `hover:border-[rgb(61,69,85)]` and `hover:-translate-y-[3px]`. Tag pill uses inline rgba on `var(--blue)` for fill and stroke.
+- **Developer checklist row:** `bg-surface`, full border + `border-l-[3px] border-l-accent`, check icon `text-accent` / `stroke="currentColor"`.
+- **Footer copyright:** `text-[rgb(61,69,85)]` — intentional tertiary gray (do not use `text-border`; `--border` is too dark for body text).
 
 ## Tailwind vs inline styles
 
-**Default rule:** Prefer Tailwind utilities. Reference tokens with Tailwind v4’s CSS-variable shorthand, e.g. `bg-(--surface)`, `text-(--accent)`, `border-(--border)`, `text-(--muted)`, `from-(--accent)`, `to-(--blue)`. These compile to `var(--surface)`, etc., and stay aligned with `globals.css`.
+**Default rule:** Prefer Tailwind utilities. The seven tokens are registered in `globals.css` inside `@theme inline` as `--color-*`, so you get utilities like `bg-surface`, `text-accent`, `border-border`, `text-muted`, `from-accent`, `to-blue` without extra config.
 
-**`tailwind.config.ts`:** The file maps the same seven names to `var(--…)` under `theme.extend.colors`. In this repo’s Tailwind v4 setup, that file is loaded only if you opt in from CSS (for example `@config "./tailwind.config.ts"` next to `@import "tailwindcss"` in `globals.css`). Until then, the parenthesis form (`bg-(--surface)`) is what the build emits. After opting in, you can also use short names like `bg-surface`, `text-accent`, `border-border`.
+**`tailwind.config.ts`:** Duplicates the same `theme.extend.colors` mappings for editors or tooling; Tailwind v4 primarily reads `@theme` from CSS. You can add `@config "./tailwind.config.ts"` after `@import "tailwindcss"` if you want the JS file to participate in the build explicitly.
 
 **When inline styles are OK:** Use a short JSX comment and keep the smallest possible `style` object when:
 

--- a/frontend-demo/app/components/Navigation.tsx
+++ b/frontend-demo/app/components/Navigation.tsx
@@ -31,8 +31,8 @@ function NavLinks({
               onClick={onNavigate}
               className={`text-[0.9rem] no-underline transition-colors duration-200 ${
                 chatActive
-                  ? "text-(--accent)"
-                  : "text-(--muted) hover:text-(--foreground)"
+                  ? "text-accent"
+                  : "text-muted hover:text-foreground"
               }`}
             >
               {label}
@@ -50,7 +50,7 @@ function GitHubButton({ className }: { className?: string }) {
       href={GITHUB_REPO}
       target="_blank"
       rel="noopener noreferrer"
-      className={`inline-flex cursor-pointer items-center justify-center rounded-md border border-(--accent) bg-transparent px-[18px] py-[7px] text-[0.85rem] text-(--accent) no-underline transition-all duration-200 hover:bg-(--accent) hover:text-black ${className ?? ""}`}
+      className={`inline-flex cursor-pointer items-center justify-center rounded-md border border-accent bg-transparent px-[18px] py-[7px] text-[0.85rem] text-accent no-underline transition-all duration-200 hover:bg-accent hover:text-black ${className ?? ""}`}
     >
       GitHub
     </a>
@@ -63,19 +63,19 @@ export default function Navigation() {
 
   return (
     <header
-      className="sticky top-0 z-[100] border-b border-(--border) backdrop-blur-[14px]"
+      className="sticky top-0 z-[100] border-b border-border backdrop-blur-[14px]"
       style={{ background: "rgba(10,12,16,0.88)" }}
     >
-      {/* Exact header scrim (88% of page background) — kept as inline style; token opacity with backdrop is finicky in utilities */}
+      {/* Header scrim: 88% of page background rgba — inline for exact match with backdrop-blur */}
       <nav className="mx-auto flex min-h-[60px] max-w-[1100px] items-center justify-between gap-4 px-4">
         <Link
           href="/"
-          className="shrink-0 font-[family-name:JetBrains_Mono,monospace] text-[1.05rem] font-bold text-(--accent) no-underline"
+          className="shrink-0 font-mono text-[1.05rem] font-bold text-accent no-underline"
         >
           Chat
-          <span className="text-(--foreground)/45">&lt;</span>
+          <span className="text-foreground/45">&lt;</span>
           Vector
-          <span className="text-(--foreground)/45">&gt;</span>
+          <span className="text-foreground/45">&gt;</span>
         </Link>
 
         <ul className="m-0 hidden list-none flex-1 flex-row flex-wrap items-center justify-center gap-8 p-0 md:flex">
@@ -89,7 +89,7 @@ export default function Navigation() {
             aria-expanded={mobileOpen}
             aria-label={mobileOpen ? "Close menu" : "Open menu"}
             onClick={() => setMobileOpen((o) => !o)}
-            className="cursor-pointer rounded-md border border-(--border) bg-transparent px-3 py-2 text-base leading-none text-(--foreground) md:hidden"
+            className="cursor-pointer rounded-md border border-border bg-transparent px-3 py-2 text-base leading-none text-foreground md:hidden"
           >
             {mobileOpen ? "✕" : "☰"}
           </button>
@@ -97,7 +97,7 @@ export default function Navigation() {
       </nav>
 
       {mobileOpen ? (
-        <div className="flex flex-col gap-4 border-t border-(--border) p-4 md:hidden">
+        <div className="flex flex-col gap-4 border-t border-border p-4 md:hidden">
           <ul className="m-0 flex list-none flex-col gap-4 p-0">
             <NavLinks
               pathname={pathname}

--- a/frontend-demo/app/globals.css
+++ b/frontend-demo/app/globals.css
@@ -9,6 +9,7 @@
    - Border:     #1e2530
    - Text:       #e8edf5
    - Muted:      #6b7685
+   - Subtle:     #3d4555 (tertiary text — between border and muted)
    - Accent:     #00e5a0 (teal green)
    - Blue:       #0080ff
    ============================================= */
@@ -19,21 +20,31 @@
   --surface: #111418;
   --border: #1e2530;
   --muted: #6b7685;
+  --subtle: #3d4555;
   --accent: #00e5a0;
   --blue: #0080ff;
 }
 
 @theme inline {
+  /* Colors — semantic tokens */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-surface: var(--surface);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
+  --color-subtle: var(--subtle);
+  --color-accent: var(--accent);
+  --color-blue: var(--blue);
+
+  /* Fonts */
+  --font-sans: 'DM Sans', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
 }
 
 body {
-  background: #0a0c10;
-  color: #e8edf5;
-  font-family: 'DM Sans', sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
 }
 
 html {

--- a/frontend-demo/app/layout.tsx
+++ b/frontend-demo/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navigation from "./components/Navigation";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "ChatVector",
@@ -26,9 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <Navigation />
         {children}
       </body>

--- a/frontend-demo/app/page.tsx
+++ b/frontend-demo/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
 
 const GITHUB_REPO = "https://github.com/chatvector-ai/chatvector-ai";
 
@@ -60,17 +59,17 @@ function HeroCodeBlock() {
 
   return (
     <div className="mt-12 w-full max-w-[700px]">
-      <div className="overflow-hidden rounded-xl border border-(--border) bg-(--surface)">
-        <div className="flex items-center gap-2 border-b border-(--border) bg-[rgb(24,28,34)] px-4 py-3">
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <div className="flex items-center gap-2 border-b border-border bg-[rgb(24,28,34)] px-4 py-3">
+          {/* macOS traffic-light dots — intentional non-token colors */}
           <div className="size-2.5 rounded-full bg-[rgb(255,95,87)]" />
           <div className="size-2.5 rounded-full bg-[rgb(254,188,46)]" />
           <div className="size-2.5 rounded-full bg-[rgb(40,200,64)]" />
-          <span className="ml-auto font-[family-name:JetBrains_Mono,monospace] text-xs text-(--muted)">
+          <span className="ml-auto font-mono text-xs text-muted">
             quickstart.py
           </span>
         </div>
-        {/* Each token uses inline `color` — driven by the highlight map above */}
-        <pre className="m-0 overflow-x-auto px-6 py-5 font-[family-name:JetBrains_Mono,monospace] text-[0.82rem] leading-[1.75]">
+        <pre className="m-0 overflow-x-auto px-6 py-5 font-mono text-[0.82rem] leading-[1.75]">
           {lines.map((t, i) =>
             t.type === "br" ? (
               <br key={i} />
@@ -100,7 +99,7 @@ function Hero() {
       id="hero"
       className="relative flex min-h-[90vh] flex-col items-center justify-center overflow-hidden px-8 pb-16 pt-20 text-center"
     >
-      {/* Repeating grid: two linear gradients + var(--border) — not a single Tailwind utility */}
+      {/* Repeating grid: two linear-gradients referencing --border — Tailwind cannot express this */}
       <div
         className="pointer-events-none absolute inset-0 opacity-30"
         style={{
@@ -109,7 +108,7 @@ function Hero() {
           backgroundSize: "60px 60px",
         }}
       />
-      {/* Tailwind cannot express this radial gradient — kept as inline style */}
+      {/* Radial glow — Tailwind cannot express arbitrary radial-gradient */}
       <div
         className="pointer-events-none absolute left-1/2 top-[20%] h-[300px] w-[600px] -translate-x-1/2"
         style={{
@@ -117,27 +116,27 @@ function Hero() {
             "radial-gradient(ellipse,rgba(0,229,160,0.13) 0%,transparent 70%)",
         }}
       />
-      {/* Hero chip: exact rgba alpha on accent — kept inline to match previous design */}
+      {/* Hero chip: sub-10% alpha on accent — kept inline for exact rgba match */}
       <div
-        className="relative z-[1] mb-8 inline-flex items-center gap-2 rounded-full px-[18px] py-1.5 font-[family-name:JetBrains_Mono,monospace] text-[0.8rem] text-(--accent)"
+        className="relative z-[1] mb-8 inline-flex items-center gap-2 rounded-full px-[18px] py-1.5 font-mono text-[0.8rem] text-accent"
         style={{
           background: "rgba(0,229,160,0.08)",
           border: "1px solid rgba(0,229,160,0.25)",
         }}
       >
-        <span className="size-[7px] rounded-full bg-(--accent) [animation:pulse_2s_infinite]" />
+        <span className="size-[7px] rounded-full bg-accent [animation:pulse_2s_infinite]" />
         Open-source · RAG Engine for Developers
       </div>
 
-      <h1 className="relative z-[1] max-w-[820px] text-[clamp(2.4rem,5vw,4.2rem)] font-semibold leading-[1.12] tracking-[-1.5px] text-(--foreground)">
+      <h1 className="relative z-[1] max-w-[820px] text-[clamp(2.4rem,5vw,4.2rem)] font-semibold leading-[1.12] tracking-[-1.5px] text-foreground">
         Build RAG apps that{" "}
-        <span className="bg-gradient-to-r from-(--accent) to-(--blue) bg-clip-text text-transparent">
+        <span className="bg-gradient-to-r from-accent to-blue bg-clip-text text-transparent">
           actually understand
         </span>{" "}
         your data.
       </h1>
 
-      <p className="relative z-[1] mx-auto mt-6 max-w-[540px] text-[1.1rem] font-light leading-[1.7] text-(--muted)">
+      <p className="relative z-[1] mx-auto mt-6 max-w-[540px] text-[1.1rem] font-light leading-[1.7] text-muted">
         ChatVector is a high-performance retrieval-augmented generation engine —
         ingest any document, retrieve semantically, and get LLM-powered answers
         in minutes.
@@ -146,21 +145,16 @@ function Hero() {
       <div className="relative z-[1] mt-10 flex flex-wrap justify-center gap-4">
         <a
           href={GITHUB_REPO}
-          className="flex cursor-pointer items-center gap-2 rounded-lg border-none bg-(--accent) px-7 py-3 text-[0.95rem] font-semibold text-black no-underline transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,229,160,0.25)]"
+          className="flex cursor-pointer items-center gap-2 rounded-lg border-none bg-accent px-7 py-3 text-[0.95rem] font-semibold text-black no-underline transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,229,160,0.25)]"
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.11.82-.26.82-.57v-2c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.74.08-.73.08-.73 1.21.08 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5 1 .11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.14 3 .4 2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.69.82.57C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z" />
           </svg>
           View on GitHub
         </a>
         <Link
           href="/chat"
-          className="flex cursor-pointer items-center gap-2 rounded-lg border border-(--border) bg-transparent px-7 py-3 text-[0.95rem] font-medium text-(--foreground) no-underline transition-all duration-200 hover:border-[rgb(61,69,85)] hover:bg-(--surface)"
+          className="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-transparent px-7 py-3 text-[0.95rem] font-medium text-foreground no-underline transition-all duration-200 hover:border-[rgb(61,69,85)] hover:bg-surface"
         >
           <svg
             width="16"
@@ -191,10 +185,10 @@ function PipelineStep({
   desc: string;
 }) {
   return (
-    <div className="flex items-start gap-3.5 border-b border-(--border) py-3.5">
-      {/* Step index badge: precise accent translucency */}
+    <div className="flex items-start gap-3.5 border-b border-border py-3.5">
+      {/* Step badge: sub-20% alpha on accent — kept inline for exact rgba match */}
       <div
-        className="flex size-7 shrink-0 items-center justify-center rounded-md border font-[family-name:JetBrains_Mono,monospace] text-xs font-bold text-(--accent)"
+        className="flex size-7 shrink-0 items-center justify-center rounded-md border font-mono text-xs font-bold text-accent"
         style={{
           background: "rgba(0,229,160,0.1)",
           borderColor: "rgba(0,229,160,0.2)",
@@ -203,10 +197,10 @@ function PipelineStep({
         {num}
       </div>
       <div>
-        <h4 className="mb-0.5 text-[0.9rem] font-medium text-(--foreground)">
+        <h4 className="mb-0.5 text-[0.9rem] font-medium text-foreground">
           {title}
         </h4>
-        <p className="m-0 text-[0.82rem] text-(--muted)">{desc}</p>
+        <p className="m-0 text-[0.82rem] text-muted">{desc}</p>
       </div>
     </div>
   );
@@ -236,36 +230,36 @@ function WhatIs() {
     },
   ];
   return (
-    <section id="about" className="bg-(--background) px-8 py-24">
+    <section id="about" className="bg-background px-8 py-24">
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-4 font-[family-name:JetBrains_Mono,monospace] text-[0.78rem] uppercase tracking-[2px] text-(--accent)">
+        <p className="mb-4 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
           {"// what is chatvector"}
         </p>
-        <h2 className="mb-5 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-(--foreground)">
+        <h2 className="mb-5 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-foreground">
           RAG that&apos;s sharp, fast,
           <br />
           and open source.
         </h2>
-        <p className="max-w-[560px] text-[1.05rem] font-light leading-[1.7] text-(--muted)">
+        <p className="max-w-[560px] text-[1.05rem] font-light leading-[1.7] text-muted">
           ChatVector handles the entire retrieval pipeline — from raw documents
           to grounded LLM responses — so you can focus on building, not
           plumbing.
         </p>
 
-        <div className="mt-12 grid grid-cols-1 items-center gap-12 md:grid-cols-2 md:gap-12">
+        <div className="mt-12 grid grid-cols-1 items-center gap-12 md:grid-cols-2">
           <div>
-            <p className="mb-5 text-[0.95rem] leading-[1.8] text-(--muted)">
+            <p className="mb-5 text-[0.95rem] leading-[1.8] text-muted">
               Most RAG implementations are fragile, slow, or locked into a
               vendor. ChatVector is different — a clean, composable engine built
               for developers who want full control.
             </p>
-            <p className="text-[0.95rem] leading-[1.8] text-(--muted)">
+            <p className="text-[0.95rem] leading-[1.8] text-muted">
               Swap your vector store, your LLM, or your chunking strategy
               without rewriting your app. Built on battle-tested primitives.
               Runs anywhere Python runs.
             </p>
           </div>
-          <div className="rounded-xl border border-(--border) bg-(--surface) p-6">
+          <div className="rounded-xl border border-border bg-surface p-6">
             {steps.map((s) => (
               <PipelineStep key={s.num} {...s} />
             ))}
@@ -342,29 +336,26 @@ function FeatureCard({
   desc: string;
   tag: string;
 }) {
-  const [hovered, setHovered] = useState(false);
+  // Pure CSS hover via group — no JS state needed
   return (
-    <div
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className={`cursor-default rounded-xl border p-6 transition-all duration-[250ms] bg-(--background) ${
-        hovered
-          ? "-translate-y-[3px] border-[rgb(61,69,85)]"
-          : "translate-y-0 border-(--border)"
-      }`}
-    >
-      {/* Icon tile fill and glyph color come from FEATURES[] (per-card palette) */}
+    <div className="group cursor-default rounded-xl border border-border bg-background p-6 transition-all duration-[250ms] hover:-translate-y-[3px] hover:border-[rgb(61,69,85)]">
+      {/* Icon tile fill and glyph color are per-card (feature palette, not design tokens) */}
       <div
         className="mb-4 flex size-10 items-center justify-center rounded-[10px] text-[1.1rem]"
         style={{ background: bg }}
       >
         <span style={{ color }}>{icon}</span>
       </div>
-      <h3 className="mb-2 text-base font-medium text-(--foreground)">
-        {title}
-      </h3>
-      <p className="m-0 text-[0.85rem] leading-snug text-(--muted)">{desc}</p>
-      <div className="mt-3 inline-block rounded border border-[color-mix(in_srgb,var(--blue)_20%,transparent)] bg-[color-mix(in_srgb,var(--blue)_10%,transparent)] px-2.5 py-0.5 font-[family-name:JetBrains_Mono,monospace] text-[0.72rem] text-(--blue)">
+      <h3 className="mb-2 text-base font-medium text-foreground">{title}</h3>
+      <p className="m-0 text-[0.85rem] leading-snug text-muted">{desc}</p>
+      {/* Tag badge: sub-20% alpha on blue — kept inline for exact rgba match */}
+      <div
+        className="mt-3 inline-block rounded px-2.5 py-0.5 font-mono text-[0.72rem] text-blue"
+        style={{
+          background: "rgba(0,128,255,0.1)",
+          border: "1px solid rgba(0,128,255,0.2)",
+        }}
+      >
         {tag}
       </div>
     </div>
@@ -373,12 +364,12 @@ function FeatureCard({
 
 function Features() {
   return (
-    <section id="features" className="bg-(--surface) px-8 py-24">
+    <section id="features" className="bg-surface px-8 py-24">
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-4 font-[family-name:JetBrains_Mono,monospace] text-[0.78rem] uppercase tracking-[2px] text-(--accent)">
+        <p className="mb-4 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
           {"// capabilities"}
         </p>
-        <h2 className="mb-12 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-(--foreground)">
+        <h2 className="mb-12 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-foreground">
           Everything you need.
           <br />
           Nothing you don&apos;t.
@@ -485,27 +476,27 @@ function Developers() {
   ];
 
   return (
-    <section id="developers" className="bg-(--background) px-8 py-24">
+    <section id="developers" className="bg-background px-8 py-24">
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-4 font-[family-name:JetBrains_Mono,monospace] text-[0.78rem] uppercase tracking-[2px] text-(--accent)">
+        <p className="mb-4 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
           {"// built for developers"}
         </p>
-        <h2 className="mb-4 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-(--foreground)">
+        <h2 className="mb-4 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-foreground">
           Designed for people who
           <br />
           read the source code.
         </h2>
-        <p className="mb-12 max-w-[540px] text-[1.05rem] font-light leading-[1.7] text-(--muted)">
+        <p className="mb-12 max-w-[540px] text-[1.05rem] font-light leading-[1.7] text-muted">
           No drag-and-drop. No &quot;AI magic&quot;. Just clean Python APIs,
           sensible defaults, and full control when you need it.
         </p>
 
-        <div className="grid grid-cols-1 items-center gap-12 md:grid-cols-2 md:gap-12">
+        <div className="grid grid-cols-1 items-center gap-12 md:grid-cols-2">
           <div className="flex flex-col gap-4">
             {DEV_POINTS.map((p) => (
               <div
                 key={p.title}
-                className="flex items-start gap-3.5 rounded-r-[10px] border border-(--border) border-l-[3px] border-l-(--accent) bg-(--surface) py-4 pl-5 pr-4"
+                className="flex items-start gap-3.5 rounded-r-[10px] border border-border border-l-[3px] border-l-accent bg-surface py-4 pl-5 pr-4"
               >
                 <svg
                   width="16"
@@ -514,31 +505,31 @@ function Developers() {
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2.5"
-                  className="mt-0.5 shrink-0 text-(--accent)"
+                  className="mt-0.5 shrink-0 text-accent"
                 >
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
                 <div>
-                  <h4 className="mb-0.5 text-[0.92rem] font-medium text-(--foreground)">
+                  <h4 className="mb-0.5 text-[0.92rem] font-medium text-foreground">
                     {p.title}
                   </h4>
-                  <p className="m-0 text-[0.82rem] text-(--muted)">{p.desc}</p>
+                  <p className="m-0 text-[0.82rem] text-muted">{p.desc}</p>
                 </div>
               </div>
             ))}
           </div>
 
-          <div className="overflow-hidden rounded-xl border border-(--border) bg-(--surface)">
-            <div className="flex items-center gap-2 border-b border-(--border) bg-[rgb(24,28,34)] px-4 py-3">
+          <div className="overflow-hidden rounded-xl border border-border bg-surface">
+            <div className="flex items-center gap-2 border-b border-border bg-[rgb(24,28,34)] px-4 py-3">
+              {/* macOS traffic-light dots — intentional non-token colors */}
               <div className="size-2.5 rounded-full bg-[rgb(255,95,87)]" />
               <div className="size-2.5 rounded-full bg-[rgb(254,188,46)]" />
               <div className="size-2.5 rounded-full bg-[rgb(40,200,64)]" />
-              <span className="ml-auto font-[family-name:JetBrains_Mono,monospace] text-xs text-(--muted)">
+              <span className="ml-auto font-mono text-xs text-muted">
                 custom_pipeline.py
               </span>
             </div>
-            {/* Per-span colors mirror the sample Python highlighter */}
-            <pre className="m-0 overflow-x-auto px-6 py-5 font-[family-name:JetBrains_Mono,monospace] text-[0.82rem] leading-[1.75]">
+            <pre className="m-0 overflow-x-auto px-6 py-5 font-mono text-[0.82rem] leading-[1.75]">
               {codeLines.map((line, i) => (
                 <div key={i}>
                   {line.parts.map((p, j) => (
@@ -570,9 +561,9 @@ const FOOTER_LINKS: { label: string; href: string; external?: boolean }[] = [
 
 function Footer() {
   return (
-    <footer className="border-t border-(--border) px-8 py-10">
+    <footer className="border-t border-border px-8 py-10">
       <div className="mx-auto flex max-w-[1100px] flex-wrap items-center justify-between gap-6">
-        <div className="font-[family-name:JetBrains_Mono,monospace] text-base font-bold text-(--accent)">
+        <div className="font-mono text-base font-bold text-accent">
           ChatVector
         </div>
         <div className="flex flex-wrap gap-8">
@@ -583,13 +574,14 @@ function Footer() {
               {...(external
                 ? { target: "_blank", rel: "noopener noreferrer" }
                 : {})}
-              className="text-[0.88rem] text-(--muted) no-underline transition-colors duration-200 hover:text-(--foreground)"
+              className="text-[0.88rem] text-muted no-underline transition-colors duration-200 hover:text-foreground"
             >
               {label}
             </a>
           ))}
         </div>
-        <div className="text-[0.82rem] text-[rgb(61,69,85)]">
+        {/* --subtle is dimmer than --muted but still readable on --background (unlike --border) */}
+        <div className="text-[0.82rem] text-subtle">
           © 2026 ChatVector · Open Source · MIT
         </div>
       </div>
@@ -598,8 +590,9 @@ function Footer() {
 }
 
 export default function Home() {
+  // Font and background set globally in globals.css body rule — no inline style needed here
   return (
-    <div className="min-h-screen bg-(--background) font-[family-name:DM_Sans,sans-serif] text-(--foreground)">
+    <div className="min-h-screen bg-background text-foreground">
       <Hero />
       <WhatIs />
       <Features />

--- a/frontend-demo/tailwind.config.ts
+++ b/frontend-demo/tailwind.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
         border: "var(--border)",
         foreground: "var(--foreground)",
         muted: "var(--muted)",
+        subtle: "var(--subtle)",
         accent: "var(--accent)",
         blue: "var(--blue)",
       },


### PR DESCRIPTION
## Summary
Wires the marketing homepage and navigation to shared CSS design tokens and Tailwind utilities, replaces inline hex styling, and documents the system for contributors.

## Changes
- **globals.css**: `:root` tokens; `@theme inline` for all semantic colors (including `--subtle` for tertiary text) and DM Sans / JetBrains Mono fonts; body uses tokens.
- **page.tsx** / **Navigation.tsx**: Token-based utilities (`bg-surface`, `text-accent`, `border-border`, `text-subtle`, etc.); inline styles only for gradients, exact rgba, and syntax highlighting.
- **layout.tsx**: Remove unused Geist `next/font` setup; fonts come from `globals.css`.
- **tailwind.config.ts**: `theme.extend.colors` mirrors all eight token names for tooling consistency.
- **FRONTEND.md**: Design system reference (palette, typography, layout, patterns, Tailwind vs inline).

## Notes
- `.vscode/settings.json` with `css.lint.unknownAtRules: ignore` was added locally but `.vscode/` is gitignored; teams can add the same rule or un-ignore if desired.

## Verify
- `npm run lint` and `npm run build` pass in `frontend-demo/`.

Made with [Cursor](https://cursor.com)