### PR TITLE
refactor(chat): design tokens for chat UI

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -26,7 +26,7 @@ export default function ChatPage() {
   } = useChat();
 
   return (
-    <div className="flex flex-col h-screen bg-gray-950 text-white">
+    <div className="flex flex-col h-screen bg-background text-foreground">
       {showModal && (
         <UploadModal
           onClose={() => setShowModal(false)}

--- a/frontend-demo/app/components/chat/ChatInput.tsx
+++ b/frontend-demo/app/components/chat/ChatInput.tsx
@@ -46,16 +46,16 @@ export default function ChatInput({
         />
       )}
       {attachment?.status === "processing" && (
-        <p className="px-4 pb-1 text-xs text-amber-400 bg-gray-900">
+        <p className="px-4 pb-1 text-xs text-amber-400 bg-background">
           Document still processing — sending is disabled until it is ready.
         </p>
       )}
       {removeError && (
-        <p className="px-4 pb-1 text-xs text-red-400 bg-gray-900">{removeError}</p>
+        <p className="px-4 pb-1 text-xs text-red-400 bg-background">{removeError}</p>
       )}
 
-      <div className="px-4 py-3 border-t border-gray-800 bg-gray-900">
-        <div className="flex items-center gap-2 bg-gray-800 rounded-xl px-4 py-2">
+      <div className="px-4 py-3 border-t border-border bg-background">
+        <div className="flex items-center gap-2 bg-surface rounded-xl px-4 py-2">
           <UploadButton onClick={onUploadClick} />
           <input
             type="text"
@@ -68,7 +68,7 @@ export default function ChatInput({
                 : "Ask about your document..."
             }
             disabled={inflight}
-            className="flex-1 bg-transparent outline-none text-sm text-white placeholder-gray-500 disabled:opacity-50"
+            className="flex-1 bg-transparent outline-none text-sm text-foreground placeholder:text-muted disabled:opacity-50"
           />
           <button
             type="button"
@@ -85,14 +85,14 @@ export default function ChatInput({
             }
             className={`w-8 h-8 rounded-lg flex items-center justify-center transition ${
               sendDisabled
-                ? "bg-gray-600 cursor-not-allowed opacity-50"
-                : "bg-indigo-600 hover:bg-indigo-500 cursor-pointer"
+                ? "bg-surface cursor-not-allowed opacity-50"
+                : "bg-accent hover:bg-accent/80 cursor-pointer text-black"
             }`}
           >
             <Send size={15} />
           </button>
         </div>
-        <p className="text-center text-xs text-gray-600 mt-2">
+        <p className="text-center text-xs text-muted mt-2">
           ChatVector may make mistakes. Always verify important information.
         </p>
       </div>

--- a/frontend-demo/app/components/chat/MessageList.tsx
+++ b/frontend-demo/app/components/chat/MessageList.tsx
@@ -28,15 +28,23 @@ export default function MessageList({ messages, inflight, bottomRef }: Props) {
           key={msg.id}
           className={`flex items-end gap-2 ${msg.sender === "user" ? "flex-row-reverse" : "flex-row"}`}
         >
-          <div className={`w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center ${msg.sender === "ai" ? "bg-indigo-600" : "bg-gray-600"}`}>
+          <div
+            className={`w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center ${
+              msg.sender === "ai" ? "bg-accent text-black" : "bg-surface border border-border"
+            }`}
+          >
             {msg.sender === "ai" ? <Bot size={16} /> : <User size={16} />}
           </div>
-          <div className={`max-w-[75%] md:max-w-[60%] px-4 py-3 rounded-2xl text-sm leading-relaxed ${msg.sender === "ai" ? "bg-gray-800 text-gray-100 rounded-bl-none" : "bg-indigo-600 text-white rounded-br-none"}`}>
+          <div
+            className={`max-w-[75%] md:max-w-[60%] px-4 py-3 rounded-2xl text-sm leading-relaxed ${
+              msg.sender === "ai" ? "bg-surface text-foreground rounded-bl-none" : "bg-accent text-black rounded-br-none"
+            }`}
+          >
             {msg.text}
             {msg.sender === "ai" && msg.sources && msg.sources.length > 0 && (
               <div className="mt-2 flex flex-col gap-1">
                 {deduplicatedSources(msg.sources).map((s, i) => (
-                  <span key={i} className="text-xs text-gray-500">
+                  <span key={i} className="text-xs text-muted">
                     {s.file_name}
                     {s.page_number != null ? ` · p.${s.page_number}` : ""}
                   </span>
@@ -44,7 +52,7 @@ export default function MessageList({ messages, inflight, bottomRef }: Props) {
               </div>
             )}
             {msg.sender === "ai" && msg.chunks === 0 && (
-              <p className="mt-1 text-xs text-gray-500 italic">
+              <p className="mt-1 text-xs text-muted italic">
                 No relevant content found in this document.
               </p>
             )}
@@ -53,10 +61,10 @@ export default function MessageList({ messages, inflight, bottomRef }: Props) {
       ))}
       {inflight && (
         <div className="flex items-end gap-2">
-          <div className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center bg-indigo-600">
+          <div className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center bg-accent text-black">
             <Bot size={16} />
           </div>
-          <div className="px-4 py-3 rounded-2xl rounded-bl-none bg-gray-800 text-gray-400 text-sm animate-pulse">
+          <div className="px-4 py-3 rounded-2xl rounded-bl-none bg-surface text-muted text-sm animate-pulse">
             Thinking...
           </div>
         </div>


### PR DESCRIPTION
Replaces hardcoded Tailwind `gray-*` and `indigo-*` classes in chat components with app design tokens (`bg-background`, `bg-surface`, `border-border`, `text-foreground`, `text-muted`, `bg-accent`) for consistency with the homepage dark theme. No layout or logic changes; amber/red status colors unchanged.

Closes #192
