### PR TITLE
feat: add /roadmap page to frontend-demo site #203

### DIFF
--- a/frontend-demo/app/roadmap/page.tsx
+++ b/frontend-demo/app/roadmap/page.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import Link from 'next/link';
+
+// Data for the Roadmap phases
+const phases = [
+  {
+    number: "Phase 1",
+    title: "Stabilize & Optimize Core Engine",
+    status: "Complete",
+    statusStyles: "bg-accent text-black",
+    description: "Core RAG backend hardened for reliability, observability, and performance. All work shipped."
+  },
+  {
+    number: "Phase 2",
+    title: "Enhance Developer Experience",
+    status: "Current",
+    statusStyles: "bg-blue-600 text-white", // Note: Ensure 'bg-blue-600' exists or use project's blue token
+    description: "Backend and frontend improvements focused on making the project easier to use and contribute to."
+  },
+  {
+    number: "Phase 3",
+    title: "Scale & Specialize",
+    status: "Later",
+    statusStyles: "bg-surface text-muted border border-border",
+    description: "Production-ready document intelligence platform. Authentication, multi-tenancy, specialized pipelines, ecosystem growth."
+  }
+];
+
+export default function RoadmapPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground py-20 px-4">
+      <div className="max-w-[720px] mx-auto">
+        
+        {/* Section Kicker - Mono styled as per requirements */}
+        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
+          Future Outlook
+        </p>
+
+        <h1 className="text-4xl font-bold mb-12 tracking-tight">Project Roadmap</h1>
+
+        <div className="grid gap-6">
+          {phases.map((phase, i) => (
+            <section 
+              key={i} 
+              className="bg-surface border border-border border-l-[3px] border-l-accent p-8 rounded-r-xl shadow-sm"
+            >
+              <div className="flex items-center justify-between mb-4">
+                <span className="font-mono text-[0.7rem] uppercase tracking-widest text-accent/80">
+                  {phase.number}
+                </span>
+                <span className={`px-3 py-1 rounded-full text-[0.65rem] font-bold uppercase tracking-wider ${phase.statusStyles}`}>
+                  {phase.status}
+                </span>
+              </div>
+              
+              <h3 className="text-xl font-semibold mb-3 text-foreground">
+                {phase.title}
+              </h3>
+              
+              <p className="text-muted text-[1rem] leading-[1.8]">
+                {phase.description}
+              </p>
+            </section>
+          ))}
+        </div>
+
+        {/* Footer & Links Section */}
+        <div className="mt-16 pt-8 border-t border-border flex flex-col gap-6">
+          <div>
+            <p className="text-muted text-sm mb-2">Want to see what we&apos;re building right now?</p>
+            <Link 
+              href="https://github.com/orgs/chatvector-ai/projects/1" 
+              className="text-accent hover:text-accent/80 transition-colors font-medium inline-flex items-center gap-2"
+            >
+              Check the ChatVector-AI Development Board →
+            </Link>
+          </div>
+          
+          <p className="text-muted text-sm italic border-l border-border pl-4">
+            For full roadmap details, see{" "}
+            <Link 
+              href="https://github.com/chatvector-ai/chatvector-ai/blob/main/ROADMAP.md" 
+              className="underline hover:text-foreground transition-colors"
+            >
+              ROADMAP.md on GitHub
+            </Link>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-demo/app/roadmap/page.tsx
+++ b/frontend-demo/app/roadmap/page.tsx
@@ -8,21 +8,21 @@ const phases = [
     title: "Stabilize & Optimize Core Engine",
     status: "Complete",
     statusStyles: "bg-accent text-black",
-    description: "Core RAG backend hardened for reliability, observability, and performance. All work shipped."
+    description: "Core RAG backend hardened for reliability, observability, and performance. Shipped features include a robust ingestion pipeline, centralized retry logic, and built-in observability."
   },
   {
     number: "Phase 2",
     title: "Enhance Developer Experience",
     status: "Current",
-    statusStyles: "bg-blue-600 text-white", // Note: Ensure 'bg-blue-600' exists or use project's blue token
-    description: "Backend and frontend improvements focused on making the project easier to use and contribute to."
+    statusStyles: "bg-blue text-white",
+    description: "Active work areas focusing on a Redis-backed durable ingestion queue, improved observability, advanced chunking strategies, and wiring up the document upload UI."
   },
   {
     number: "Phase 3",
     title: "Scale & Specialize",
     status: "Later",
     statusStyles: "bg-surface text-muted border border-border",
-    description: "Production-ready document intelligence platform. Authentication, multi-tenancy, specialized pipelines, ecosystem growth."
+    description: "Long-term vision for a production-ready document intelligence platform. Future goals include authentication, multi-tenancy, specialized pipelines, and ecosystem growth."
   }
 ];
 


### PR DESCRIPTION
## 🚀 Description
This PR implements the new `/roadmap` page for the `frontend-demo` site as specified in issue #203. It provides a clear, high-level summary of the project's development phases for contributors and users.

---

## 🔧 Changes Made
- **New Route**: Created `frontend-demo/app/roadmap/page.tsx`.
- **Phase Breakdown**: Summarized the three core phases (Stabilize, Enhance DX, Scale) based on the project's master roadmap.
- **UI & Layout**: 
    - Used a centered `max-w-[720px]` column.
    - Implemented `font-mono` section kickers with custom tracking.
    - Added specific status badges: `bg-accent` (Complete), `bg-blue` (Current), and `bg-surface` (Later).
- **Design System**: Strictly adhered to project design tokens (e.g., `text-muted`, `bg-surface`, `text-accent`) with **zero hardcoded hex values**.
- **External Links**: Added links to the GitHub Project Board and the full `ROADMAP.md` file.

---

## 🧪 Verification & Testing
- [x] Page renders correctly at `/roadmap`.
- [x] Verified all three phases display the correct status and styling.
- [x] Ran `npm run build` — **Passed**.
- [x] Ran `npm run lint` — **Passed** (fixed unescaped entity errors).

---

## ✅ Checklist
- [x] No hardcoded hex values (Design tokens only).
- [x] Followed existing project structure.
- [x] Mobile-responsive layout.