### PR TITLE
feat: polish contributors page with skeleton loading, error state, and Next/Image

### DIFF
--- a/frontend-demo/app/contributors/page.tsx
+++ b/frontend-demo/app/contributors/page.tsx
@@ -20,7 +20,7 @@ export default function ContributorsPage() {
     setLoading(true);
     setError("");
     fetch(
-      "https://api.github.com/repos/chatvector-ai/chatvector-ai/contributors"
+      "https://api.github.com/repos/chatvector-ai/chatvector-ai/contributors",
     )
       .then((res) => {
         if (!res.ok) throw new Error("Failed to fetch");
@@ -29,7 +29,7 @@ export default function ContributorsPage() {
       .then((data) => {
         // sort explicitly (even though API already does)
         const sorted = data.sort(
-          (a: Contributor, b: Contributor) => b.contributions - a.contributions
+          (a: Contributor, b: Contributor) => b.contributions - a.contributions,
         );
         setContributors(sorted);
         setLoading(false);
@@ -47,7 +47,12 @@ export default function ContributorsPage() {
   return (
     <div className="max-w-[720px] mx-auto px-4 py-10">
       <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-2">
-        {"// contributors"}
+        {"// thanks"}
+      </p>
+      <h1 className="text-3xl font-bold mb-4 text-foreground">Contributors</h1>
+      <p className="text-foreground text-[1rem] leading-[1.8] mb-8">
+        A special thanks to everyone who has contributed code, documentation,
+        ideas, or feedback. This project is shaped by the community.
       </p>
 
       {loading && (
@@ -58,8 +63,8 @@ export default function ContributorsPage() {
               className="animate-pulse bg-surface border border-border rounded-lg p-4 flex flex-col items-center gap-3"
             >
               <div className="w-16 h-16 rounded-full bg-border" />
-              <div className="h-3 w-48 rounded bg-border" />
-              <div className="h-3 w-28 rounded bg-border" />
+              <div className="h-3 w-36 md:w-48 rounded bg-border" />
+              <div className="h-3 w-24 md:w-28 rounded bg-border" />
             </div>
           ))}
         </div>

--- a/frontend-demo/app/contributors/page.tsx
+++ b/frontend-demo/app/contributors/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Image from "next/image";
 import ErrorState from "../components/ErrorState";
 
 type Contributor = {
@@ -45,10 +46,23 @@ export default function ContributorsPage() {
 
   return (
     <div className="max-w-[720px] mx-auto px-4 py-10">
-      <h1 className="text-3xl font-bold mb-6 text-foreground">Contributors</h1>
+      <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-2">
+        {"// contributors"}
+      </p>
 
       {loading && (
-        <p className="text-muted text-center mt-6">Loading contributors...</p>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <div
+              key={i}
+              className="animate-pulse bg-surface border border-border rounded-lg p-4 flex flex-col items-center gap-3"
+            >
+              <div className="w-16 h-16 rounded-full bg-border" />
+              <div className="h-3 w-48 rounded bg-border" />
+              <div className="h-3 w-28 rounded bg-border" />
+            </div>
+          ))}
+        </div>
       )}
 
       {error && (
@@ -71,10 +85,12 @@ export default function ContributorsPage() {
               rel="noopener noreferrer"
               className="bg-surface border border-border p-4 rounded-lg flex flex-col items-center hover:border-accent hover:scale-[1.02] transition"
             >
-              <img
+              <Image
                 src={c.avatar_url}
                 alt={c.login}
-                className="w-16 h-16 rounded-full mb-3"
+                width={64}
+                height={64}
+                className="rounded-full mb-3"
               />
 
               <p className="font-mono text-accent">@{c.login}</p>

--- a/frontend-demo/next.config.ts
+++ b/frontend-demo/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Polishes the contributors page with improved loading states, error handling, and a warm community-focused header.

## What changed

### Skeleton loading state
- Replaced plain "Loading contributors..." text with a 9-card skeleton grid
- Cards match the real contributor card layout with avatar circle and text placeholders
- Responsive widths (`w-36 md:w-48`, `w-24 md:w-28`) for better mobile/desktop fit

### Error state
- Replaced inline error text with the reusable `ErrorState` component
- Displays the `redirect-logo.svg`, error kicker, heading, and message
- Retry button re-triggers the GitHub API fetch

### Image optimization
- Migrated contributor avatars from plain `<img>` to Next.js `<Image>`
- Added `avatars.githubusercontent.com` to `next.config.ts` remote patterns

### Header and thank-you message
- Added `// thanks` kicker in mono accent style
- Added h1 "Contributors"
- Added warm intro paragraph thanking the community

## Why this works
- Consistent with design system tokens (no hardcoded hex)
- Improves perceived performance with skeleton loading
- Better accessibility with semantic heading structure
- Centralized error UI via reusable component

## Verification
- [x] Skeleton cards render during loading (9 cards, responsive widths)
- [x] Error state shows logo, message, and retry button
- [x] Retry button re-fetches contributors successfully
- [x] Avatars use `next/image` with remote pattern configured
- [x] Kicker, h1, and thank-you message present
- [x] `npm run build` passes in `frontend-demo/`
- [x] `npm run lint` passes in `frontend-demo/`

## Issues closed
Closes #220
Closes #230
