### PR TITLE
fix(logging): route test logs to separate files when APP_ENV=test

### DIFF
--- a/backend/logging_config/logging_config.py
+++ b/backend/logging_config/logging_config.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
@@ -36,8 +37,8 @@ class JSONFormatter(logging.Formatter):
 
 
 def setup_logging(
-    log_file: str = "logs/app.log",
-    access_log_file: str = "logs/access.log",
+    log_file: str | None = None,
+    access_log_file: str | None = None,
 ) -> None:
     """
     Logging strategy:
@@ -45,7 +46,18 @@ def setup_logging(
     - Uvicorn access logs -> logs/access.log AND console
     - No duplicate logs
     - Supports JSON format when LOG_FORMAT=JSON is set
+
+    When APP_ENV=test, writes to logs/test.log and logs/test_access.log
+    instead of the production log files to keep test output separate from
+    live server activity.
     """
+    app_env = os.environ.get("APP_ENV", "production").lower()
+    is_test = app_env == "test"
+
+    if log_file is None:
+        log_file = "logs/test.log" if is_test else "logs/app.log"
+    if access_log_file is None:
+        access_log_file = "logs/test_access.log" if is_test else "logs/access.log"
 
     logging.captureWarnings(True)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 from pathlib import Path
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
@@ -34,3 +35,22 @@ if not env_file.exists():
         + "\n",
         encoding="utf-8",
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_test_logs():
+    """Clear test log files at the start of each test session.
+
+    Prevents test output from accumulating across runs and keeps the
+    test log stream readable. Only clears logs/test.log and
+    logs/test_access.log — production log files are never touched.
+    """
+    logs_dir = BACKEND_DIR / "logs"
+    test_log_files = [
+        logs_dir / "test.log",
+        logs_dir / "test_access.log",
+    ]
+    for log_file in test_log_files:
+        if log_file.exists():
+            log_file.write_text("", encoding="utf-8")
+    yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,7 +9,11 @@ if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
 # Ensure imports relying on backend/.env do not crash test collection.
-os.environ.setdefault("APP_ENV", "production")
+# Default to "test" so log routing in logging_config.setup_logging() sends
+# output to logs/test.log when pytest is invoked directly. `make tests`
+# (Docker) already injects APP_ENV=test via docker-compose.yml, so this
+# only changes the local-pytest path.
+os.environ.setdefault("APP_ENV", "test")
 os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
 os.environ.setdefault("SUPABASE_KEY", "test-key-123")
 os.environ.setdefault("GEN_AI_KEY", "test-genai-key")
@@ -24,7 +28,7 @@ if not env_file.exists():
     env_file.write_text(
         "\n".join(
             [
-                "APP_ENV=production",
+                "APP_ENV=test",
                 "SUPABASE_URL=https://test.supabase.co",
                 "SUPABASE_KEY=test-key-123",
                 "GEN_AI_KEY=test-genai-key",

--- a/backend/tests/test_logging_config.py
+++ b/backend/tests/test_logging_config.py
@@ -1,0 +1,103 @@
+"""Tests for logging_config.setup_logging() log-file routing.
+
+Locks in the APP_ENV-based routing added in
+https://github.com/chatvector-ai/chatvector-ai/pull/236:
+
+- APP_ENV=test  -> logs/test.log + logs/test_access.log
+- otherwise     -> logs/app.log  + logs/access.log
+
+These tests would have caught the conftest.py default-to-production bug
+that let test output leak into app.log on direct-pytest runs.
+"""
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+import pytest
+
+
+def _file_handler_paths(logger: logging.Logger) -> list[str]:
+    """Return normalized basenames of every RotatingFileHandler on a logger."""
+    return [
+        os.path.basename(h.baseFilename).replace("\\", "/")
+        for h in logger.handlers
+        if isinstance(h, RotatingFileHandler)
+    ]
+
+
+@pytest.fixture
+def reset_logging():
+    """Snapshot + restore handler state around each test.
+
+    setup_logging() mutates root + uvicorn loggers globally; without this
+    fixture the side effects leak into other tests.
+    """
+    targets = [
+        logging.getLogger(),
+        logging.getLogger("uvicorn"),
+        logging.getLogger("uvicorn.error"),
+        logging.getLogger("uvicorn.access"),
+    ]
+    saved = [(lg, list(lg.handlers), lg.level, lg.propagate) for lg in targets]
+    try:
+        yield
+    finally:
+        for lg, handlers, level, propagate in saved:
+            # Close any handlers setup_logging opened so file descriptors
+            # don't leak between tests.
+            for h in lg.handlers:
+                if h not in handlers:
+                    try:
+                        h.close()
+                    except Exception:
+                        pass
+            lg.handlers = handlers
+            lg.setLevel(level)
+            lg.propagate = propagate
+
+
+def test_setup_logging_routes_to_test_files_when_app_env_is_test(
+    monkeypatch, reset_logging
+):
+    """APP_ENV=test -> root logger writes to logs/test.log;
+    uvicorn.access writes to logs/test_access.log."""
+    from logging_config.logging_config import setup_logging
+
+    monkeypatch.setenv("APP_ENV", "test")
+    setup_logging()
+
+    root_files = _file_handler_paths(logging.getLogger())
+    access_files = _file_handler_paths(logging.getLogger("uvicorn.access"))
+
+    assert "test.log" in root_files, (
+        f"expected test.log on root logger, got {root_files}"
+    )
+    assert "test_access.log" in access_files, (
+        f"expected test_access.log on uvicorn.access, got {access_files}"
+    )
+    # Negative assertion: production files must not be attached.
+    assert "app.log" not in root_files
+    assert "access.log" not in access_files
+
+
+def test_setup_logging_routes_to_production_files_when_app_env_is_development(
+    monkeypatch, reset_logging
+):
+    """APP_ENV=development (and any non-test value) -> logs/app.log +
+    logs/access.log. Confirms test routing is opt-in, not default."""
+    from logging_config.logging_config import setup_logging
+
+    monkeypatch.setenv("APP_ENV", "development")
+    setup_logging()
+
+    root_files = _file_handler_paths(logging.getLogger())
+    access_files = _file_handler_paths(logging.getLogger("uvicorn.access"))
+
+    assert "app.log" in root_files, (
+        f"expected app.log on root logger, got {root_files}"
+    )
+    assert "access.log" in access_files, (
+        f"expected access.log on uvicorn.access, got {access_files}"
+    )
+    assert "test.log" not in root_files
+    assert "test_access.log" not in access_files


### PR DESCRIPTION
Routes test output to separate log files when APP_ENV=test to keep production logs clean.

---
Submitted by [rawcell](https://github.com/quanticsoul4772/agent-harness-v2) (autonomous agent)