### PR TITLE
feat: harden providers, core config, and pin openai dependency

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -213,7 +213,14 @@ def get_embedding_dim() -> int:
     """
     raw = os.getenv("EMBEDDING_DIM")
     if raw:
-        return int(raw)
+        try:
+            return int(raw)
+        except ValueError:
+            raise ValueError(
+                f"EMBEDDING_DIM={raw!r} is not a valid integer. "
+                f"Set it to the embedding dimension of your model "
+                f"(e.g. 3072 for Gemini, 1536 for OpenAI text-embedding-3-small)."
+            )
 
     # Deferred import: avoids a circular import at module load time and
     # keeps the provider factory lazy for everything except this single call.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,7 +29,7 @@ realtime==2.24.0
 google-genai==1.6.0
 
 # -------- OpenAI --------
-openai>=1.0.0
+openai==2.31.0
 
 # -------- LangChain / RAG --------
 langchain==1.0.5

--- a/backend/services/providers/ollama.py
+++ b/backend/services/providers/ollama.py
@@ -80,7 +80,13 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
                 json={"model": self._model, "input": texts},
             )
             response.raise_for_status()
-            return response.json()["embeddings"]
+            data = response.json()
+            embeddings = data.get("embeddings") or data.get("embedding")
+            if not embeddings:
+                raise ProviderError(
+                    f"Unexpected Ollama embed response shape: {list(data.keys())}"
+                )
+            return embeddings
 
         except httpx.HTTPStatusError as exc:
             raise _classify_http_error(exc) from exc

--- a/backend/services/providers/ollama.py
+++ b/backend/services/providers/ollama.py
@@ -81,12 +81,21 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
             )
             response.raise_for_status()
             data = response.json()
-            embeddings = data.get("embeddings") or data.get("embedding")
-            if not embeddings:
-                raise ProviderError(
-                    f"Unexpected Ollama embed response shape: {list(data.keys())}"
-                )
-            return embeddings
+
+            if "embeddings" in data:
+                return data["embeddings"]
+
+            if "embedding" in data:
+                embedding = data["embedding"]
+                # legacy compatibility: Older Ollama instances return a flat list[float]
+                # for single inputs. wrap it to maintain the list[list[float]] interface.
+                if embedding and not isinstance(embedding[0], (list, tuple)):
+                    return [embedding]
+                return embedding
+
+            raise ProviderError(
+                f"Unexpected Ollama embed response shape: {list(data.keys())}"
+            )
 
         except httpx.HTTPStatusError as exc:
             raise _classify_http_error(exc) from exc

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,23 @@
+import pytest
+from core.config import get_embedding_dim
+
+def test_get_embedding_dim_valid_int(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_DIM", "1536")
+    assert get_embedding_dim() == 1536
+
+def test_get_embedding_dim_invalid_value(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_DIM", "abc")
+    with pytest.raises(ValueError) as exc:
+        get_embedding_dim()
+    
+    assert "EMBEDDING_DIM='abc' is not a valid integer" in str(exc.value)
+    assert "e.g. 3072 for Gemini" in str(exc.value)
+
+def test_get_embedding_dim_missing_uses_provider(monkeypatch):
+    monkeypatch.delenv("EMBEDDING_DIM", raising=False)
+    # This should fall back to calling get_embedding_provider().embedding_dim
+    # We mock it to avoid needing real provider setup
+    from unittest.mock import patch
+    with patch("services.providers.get_embedding_provider") as mock_get:
+        mock_get.return_value.embedding_dim = 768
+        assert get_embedding_dim() == 768

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -319,6 +319,42 @@ class TestOllamaEmbedParsing:
 
         assert result == [[0.1, 0.2], [0.3, 0.4]]
 
+    async def test_fallback_to_singular_embedding_key(self):
+        """Older Ollama versions (pre-0.1.34) use 'embedding' (singular)."""
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.ollama import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider()
+
+        fake_response = MagicMock()
+        fake_response.raise_for_status = MagicMock()
+        fake_response.json = MagicMock(
+            return_value={"embedding": [[0.1, 0.2], [0.3, 0.4]]}
+        )
+        provider._client.post = AsyncMock(return_value=fake_response)
+
+        result = await provider.embed(["a", "b"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+    async def test_missing_both_keys_raises_provider_error(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.ollama import OllamaEmbeddingProvider, ProviderError
+
+        provider = OllamaEmbeddingProvider()
+
+        fake_response = MagicMock()
+        fake_response.raise_for_status = MagicMock()
+        # Response with neither 'embeddings' nor 'embedding'
+        fake_response.json = MagicMock(return_value={"something_else": "here"})
+        provider._client.post = AsyncMock(return_value=fake_response)
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.embed(["a", "b"])
+
+        assert "Unexpected Ollama embed response shape" in str(exc.value)
+        assert "something_else" in str(exc.value)
+
 
 class TestOllamaGenerateParsing:
     """Verify OllamaLLMProvider.generate() parses response['response'] with fallback."""

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -329,13 +329,13 @@ class TestOllamaEmbedParsing:
         fake_response = MagicMock()
         fake_response.raise_for_status = MagicMock()
         fake_response.json = MagicMock(
-            return_value={"embedding": [[0.1, 0.2], [0.3, 0.4]]}
+            return_value={"embedding": [0.1, 0.2, 0.3]}
         )
         provider._client.post = AsyncMock(return_value=fake_response)
 
-        result = await provider.embed(["a", "b"])
+        result = await provider.embed(["test"])
 
-        assert result == [[0.1, 0.2], [0.3, 0.4]]
+        assert result == [[0.1, 0.2, 0.3]]
 
     async def test_missing_both_keys_raises_provider_error(self):
         from unittest.mock import AsyncMock, MagicMock


### PR DESCRIPTION
### Summary

Resolves #235

Implements three hardening fixes:
1. Adds  `embedding` key fallback for Ollama.
2. Guards `EMBEDDING_DIM` parsing in `config.py` with clear error messages.
3. Pins `openai==2.31.0` in `requirements.txt`.

### Testing
- Added and passed unit tests in `pytest`.
- Manually verified config error handling.
