### PR TITLE
feat(db): add dimensionless vector migration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -288,6 +288,33 @@ Docker Compose expands `${VAR}` from your process environment or a
 
 See `backend/.env.example` for the full list of tunables.
 
+### Upgrading from a pre-#167 Deployment
+
+Versions before PR #167 created `document_chunks.embedding` as `vector(3072)`.
+The current schema uses a dimensionless `vector` column to support multiple
+embedding providers.
+
+**Option A — Run the migration (keeps existing data):**
+
+```bash
+docker compose exec db psql -U postgres -d postgres \
+    -f /docker-entrypoint-initdb.d/002_dimensionless_vector.sql
+```
+
+Or connect directly and paste the contents of
+`backend/db/init/002_dimensionless_vector.sql`.
+
+> **Note:** existing embeddings are preserved but become incompatible if you
+> switch to a provider with a different embedding dimension. A full re-ingest
+> is required after a provider change.
+
+**Option B — Full wipe and re-ingest (simplest for dev environments):**
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
 ### Ports
 
 - **8000** — HTTP API. Expose behind a reverse proxy or load balancer.

--- a/backend/db/init/002_dimensionless_vector.sql
+++ b/backend/db/init/002_dimensionless_vector.sql
@@ -6,13 +6,22 @@
 -- A full re-ingest is required when changing providers.
 --
 -- Safe to run on a fresh database (column is already dimensionless).
+-- Guard checks pg_attribute.atttypmod: -1 = dimensionless, >0 = fixed dimension.
+-- Only runs ALTER when a fixed dimension is detected.
 
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'document_chunks'
-        AND column_name = 'embedding'
+        SELECT 1
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = 'document_chunks'
+          AND n.nspname = 'public'
+          AND a.attname = 'embedding'
+          AND a.atttypmod <> -1
+          AND a.attnum > 0
+          AND NOT a.attisdropped
     ) THEN
         ALTER TABLE document_chunks
             ALTER COLUMN embedding TYPE vector

--- a/backend/db/init/002_dimensionless_vector.sql
+++ b/backend/db/init/002_dimensionless_vector.sql
@@ -1,0 +1,21 @@
+-- Migration 002: remove fixed dimension from embedding column
+-- Required when upgrading from a deployment that used vector(3072)
+--
+-- WARNING: existing embeddings are preserved but will be incompatible
+-- if switching to a provider with a different embedding dimension.
+-- A full re-ingest is required when changing providers.
+--
+-- Safe to run on a fresh database (column is already dimensionless).
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'document_chunks'
+        AND column_name = 'embedding'
+    ) THEN
+        ALTER TABLE document_chunks
+            ALTER COLUMN embedding TYPE vector
+            USING embedding::vector;
+    END IF;
+END $$;

--- a/backend/tests/test_migration_002.py
+++ b/backend/tests/test_migration_002.py
@@ -7,10 +7,12 @@ No live database required — these are static content tests.
 What we verify:
 - File exists at the expected path
 - Targets correct table (document_chunks) and column (embedding)
-- Alters to dimensionless vector (no fixed dimension like vector(3072))
-- Has an idempotent guard via information_schema.columns
-- Includes USING clause for safe pgvector cast
-- Documents the re-ingest warning for operators
+- Alters to dimensionless vector (no fixed dimension in ALTER statement)
+- Guard uses pg_attribute.atttypmod — not just column existence
+- atttypmod <> -1 check present — skips ALTER on fresh/dimensionless installs
+- Schema filter 'public' present — avoids matching other schemas
+- USING clause present for safe pgvector cast
+- Re-ingest warning documented for operators
 """
 import re
 from pathlib import Path
@@ -30,46 +32,67 @@ def migration_sql() -> str:
     return SQL_PATH.read_text(encoding="utf-8")
 
 
+@pytest.fixture(scope="module")
+def sql_code(migration_sql) -> str:
+    """SQL with comment lines stripped — used for structural assertions."""
+    return "\n".join(
+        line for line in migration_sql.splitlines()
+        if not line.strip().startswith("--")
+    )
+
+
 def test_file_exists():
     """Migration file must exist at backend/db/init/002_dimensionless_vector.sql."""
     assert SQL_PATH.exists()
 
 
-def test_targets_correct_table(migration_sql):
-    """Must reference the document_chunks table."""
-    assert "document_chunks" in migration_sql
+def test_targets_correct_table(sql_code):
+    """Must reference document_chunks in executable SQL, not just comments."""
+    assert "document_chunks" in sql_code
 
 
-def test_targets_embedding_column(migration_sql):
-    """Must reference the embedding column."""
-    assert "embedding" in migration_sql
+def test_targets_embedding_column(sql_code):
+    """Must reference the embedding column in executable SQL."""
+    assert "embedding" in sql_code
 
 
-def test_alters_to_dimensionless_vector(migration_sql):
-    """Must alter column to plain vector with no dimension argument."""
-    # Matches: TYPE vector followed by whitespace or end-of-token (not a parenthesis)
-    assert re.search(r"TYPE\s+vector\b", migration_sql, re.IGNORECASE)
+def test_alters_to_dimensionless_vector(sql_code):
+    """ALTER statement must target plain vector with no dimension argument."""
+    assert re.search(r"TYPE\s+vector\b", sql_code, re.IGNORECASE)
 
 
-def test_no_fixed_dimension(migration_sql):
-    """Must NOT hard-code vector(N) in SQL statements — comments are excluded."""
-    # Strip comment lines so vector(3072) in comments doesn't trigger false failure
-    sql_code = "\n".join(
-        line for line in migration_sql.splitlines()
-        if not line.strip().startswith("--")
-    )
+def test_no_fixed_dimension_in_alter(sql_code):
+    """ALTER statement must NOT hard-code vector(N) — dimensionless only."""
     assert not re.search(r"vector\s*\(\s*\d+\s*\)", sql_code, re.IGNORECASE)
 
 
-def test_has_idempotent_guard(migration_sql):
-    """Must check column existence before altering — safe to re-run."""
-    assert "information_schema.columns" in migration_sql
-    assert "IF EXISTS" in migration_sql.upper()
+def test_guard_uses_pg_attribute(sql_code):
+    """Guard must use pg_attribute, not information_schema — catches fixed-dimension columns."""
+    assert "pg_attribute" in sql_code
+    # information_schema only checks existence, not dimension — must not be used as guard
+    assert "information_schema" not in sql_code
 
 
-def test_has_using_clause(migration_sql):
+def test_guard_checks_atttypmod(sql_code):
+    """Guard must check atttypmod <> -1 to skip ALTER on already-dimensionless columns."""
+    assert "atttypmod" in sql_code
+    # Verify the inequality check is present (not just the column name)
+    assert re.search(r"atttypmod\s*<>\s*-1", sql_code, re.IGNORECASE)
+
+
+def test_guard_has_schema_filter(sql_code):
+    """Guard must filter to public schema to avoid matching other schemas."""
+    assert re.search(r"nspname\s*=\s*'public'", sql_code, re.IGNORECASE)
+
+
+def test_has_if_exists_block(sql_code):
+    """Must use IF EXISTS block so migration is safe to re-run."""
+    assert "IF EXISTS" in sql_code.upper()
+
+
+def test_has_using_clause(sql_code):
     """Must include USING embedding::vector for safe pgvector type cast."""
-    assert re.search(r"USING\s+embedding::vector", migration_sql, re.IGNORECASE)
+    assert re.search(r"USING\s+embedding::vector", sql_code, re.IGNORECASE)
 
 
 def test_has_warning_comment(migration_sql):

--- a/backend/tests/test_migration_002.py
+++ b/backend/tests/test_migration_002.py
@@ -1,0 +1,77 @@
+"""
+Tests for migration 002: dimensionless vector column.
+
+Strategy: parse the SQL file and assert structural properties.
+No live database required — these are static content tests.
+
+What we verify:
+- File exists at the expected path
+- Targets correct table (document_chunks) and column (embedding)
+- Alters to dimensionless vector (no fixed dimension like vector(3072))
+- Has an idempotent guard via information_schema.columns
+- Includes USING clause for safe pgvector cast
+- Documents the re-ingest warning for operators
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+SQL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "db" / "init" / "002_dimensionless_vector.sql"
+)
+
+
+@pytest.fixture(scope="module")
+def migration_sql() -> str:
+    """Read migration file once per test session."""
+    assert SQL_PATH.exists(), f"Migration file missing: {SQL_PATH}"
+    return SQL_PATH.read_text(encoding="utf-8")
+
+
+def test_file_exists():
+    """Migration file must exist at backend/db/init/002_dimensionless_vector.sql."""
+    assert SQL_PATH.exists()
+
+
+def test_targets_correct_table(migration_sql):
+    """Must reference the document_chunks table."""
+    assert "document_chunks" in migration_sql
+
+
+def test_targets_embedding_column(migration_sql):
+    """Must reference the embedding column."""
+    assert "embedding" in migration_sql
+
+
+def test_alters_to_dimensionless_vector(migration_sql):
+    """Must alter column to plain vector with no dimension argument."""
+    # Matches: TYPE vector followed by whitespace or end-of-token (not a parenthesis)
+    assert re.search(r"TYPE\s+vector\b", migration_sql, re.IGNORECASE)
+
+
+def test_no_fixed_dimension(migration_sql):
+    """Must NOT hard-code vector(N) in SQL statements — comments are excluded."""
+    # Strip comment lines so vector(3072) in comments doesn't trigger false failure
+    sql_code = "\n".join(
+        line for line in migration_sql.splitlines()
+        if not line.strip().startswith("--")
+    )
+    assert not re.search(r"vector\s*\(\s*\d+\s*\)", sql_code, re.IGNORECASE)
+
+
+def test_has_idempotent_guard(migration_sql):
+    """Must check column existence before altering — safe to re-run."""
+    assert "information_schema.columns" in migration_sql
+    assert "IF EXISTS" in migration_sql.upper()
+
+
+def test_has_using_clause(migration_sql):
+    """Must include USING embedding::vector for safe pgvector type cast."""
+    assert re.search(r"USING\s+embedding::vector", migration_sql, re.IGNORECASE)
+
+
+def test_has_warning_comment(migration_sql):
+    """Migration must document the re-ingest requirement for operators."""
+    assert "re-ingest" in migration_sql.lower()


### PR DESCRIPTION
## Summary

Resolves #234 

Adds a SQL migration for deployments upgrading from pre-#167 schema (`vector(3072)` → dimensionless `vector`).

## Files Changed
- `backend/db/init/002_dimensionless_vector.sql` — idempotent migration script
- `backend/tests/test_migration_002.py` — static SQL structure tests
- `DEVELOPMENT.md` — upgrade path documented under Deployment

## Tests
- [x] 8 unit tests pass (`test_migration_002.py`)
- [x] Full suite passes: 223 passed