### PR TITLE
feat(frontend-demo): Kicker component, doc layout, and design consistency

### DIFF
--- a/frontend-demo/app/about/page.tsx
+++ b/frontend-demo/app/about/page.tsx
@@ -60,7 +60,7 @@ export default function AboutPage() {
 
         {/* Section 3: ChatVector vs frameworks */}
         <section className="mb-20">
-          <Kicker spacing="lg">open source</Kicker>
+          <Kicker spacing="lg">chatvector vs frameworks</Kicker>
           <div className="mt-6 overflow-x-auto rounded-xl border border-border bg-surface">
             <table className="w-full border-collapse text-left text-[0.93rem] leading-normal">
               <thead>

--- a/frontend-demo/app/about/page.tsx
+++ b/frontend-demo/app/about/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Kicker } from "@/app/components/Kicker";
 import Footer from "../components/home/Footer";
 
 export default function AboutPage() {
@@ -7,9 +8,7 @@ export default function AboutPage() {
       <div className="max-w-[720px] mx-auto px-4 py-16 flex-1">
         {/* Section 1: What is ChatVector */}
         <section className="mb-20">
-          <span className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent block mb-4">
-            What is ChatVector
-          </span>
+          <Kicker spacing="lg">what is chatvector</Kicker>
           <h1 className="text-3xl font-bold mb-6 text-foreground">
             A developer-focused RAG engine you can deploy as a service.
           </h1>
@@ -20,9 +19,7 @@ export default function AboutPage() {
 
         {/* Section 2: Who is this for */}
         <section className="mb-20">
-          <span className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent block mb-4">
-            Who is this for
-          </span>
+          <Kicker spacing="lg">who this is for</Kicker>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
             {[
               {
@@ -63,9 +60,7 @@ export default function AboutPage() {
 
         {/* Section 3: ChatVector vs frameworks */}
         <section className="mb-20">
-          <span className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent block mb-4">
-            ChatVector vs frameworks
-          </span>
+          <Kicker spacing="lg">open source</Kicker>
           <div className="mt-6 overflow-x-auto rounded-xl border border-border bg-surface">
             <table className="w-full border-collapse text-left text-[0.93rem] leading-normal">
               <thead>

--- a/frontend-demo/app/architecture/page.tsx
+++ b/frontend-demo/app/architecture/page.tsx
@@ -1,31 +1,28 @@
+import { DocLayout } from "@/app/components/DocLayout";
+import { DocPageHeader } from "@/app/components/DocPageHeader";
+import { Kicker } from "@/app/components/Kicker";
+
 export default function ArchitecturePage() {
   return (
-    <div className="max-w-[720px] mx-auto px-4 py-10">
+    <DocLayout>
+      <DocPageHeader
+        kicker="internals"
+        title="Architecture"
+        description="ChatVector is built as a production-ready RAG (Retrieval-Augmented Generation) engine — not a general-purpose framework. This page summarises how the system is structured internally so contributors and evaluators can orient quickly."
+      />
 
-      {/* Hero */}
-      <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-2">
-        Internals
-      </p>
-      <h1 className="text-3xl font-bold mb-4 text-foreground">
-        Architecture
-      </h1>
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-10">
-        ChatVector is built as a production-ready RAG (Retrieval-Augmented Generation) engine —
-        not a general-purpose framework. This page summarises how the system is structured
-        internally so contributors and evaluators can orient quickly.
-      </p>
-
-      {/* 01 — System Design */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        01 — System Design
-      </h2>
-      <h3 className="text-lg font-semibold text-foreground mb-3">
-        Layered Architecture Overview
-      </h3>
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-4">
-        The stack is deliberately layered so each concern is isolated. From top to bottom:
-      </p>
-      <pre className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-5 overflow-x-auto mb-10 text-foreground leading-[1.7]">{`┌─────────────────────────────────┐
+      <div className="mt-10 space-y-10">
+        <section>
+          <Kicker variant="numbered" spacing="sm">
+            01 — System Design
+          </Kicker>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">
+            Layered Architecture Overview
+          </h2>
+          <p className="mb-4 text-[1rem] leading-[1.8] text-foreground">
+            The stack is deliberately layered so each concern is isolated. From top to bottom:
+          </p>
+          <pre className="mb-10 overflow-x-auto rounded-xl border border-border bg-surface p-5 font-mono text-[0.82rem] leading-[1.7] text-foreground">{`┌─────────────────────────────────┐
 │        API Layer (FastAPI)      │  ← HTTP endpoints, validation
 ├─────────────────────────────────┤
 │     Ingestion / Query Logic     │  ← chunking, embedding, retrieval
@@ -34,121 +31,118 @@ export default function ArchitecturePage() {
 ├─────────────────────────────────┤
 │     Vector Store (pgvector)     │  ← similarity search in Postgres
 └─────────────────────────────────┘`}</pre>
+        </section>
 
-      {/* 02 — Database */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        02 — Database
-      </h2>
-      <h3 className="text-lg font-semibold text-foreground mb-3">
-        Database Strategy Pattern
-      </h3>
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-6">
-        ChatVector uses a <em>Strategy Pattern</em> for database access. The application code
-        never talks to a specific database driver directly — it calls a common interface backed
-        by either <strong>SQLAlchemy</strong> (local / Docker) or{" "}
-        <strong>Supabase</strong> (hosted production). Swapping backends requires only an
-        environment variable change.
-      </p>
+        <section>
+          <Kicker variant="numbered" spacing="sm">
+            02 — Database
+          </Kicker>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">
+            Database Strategy Pattern
+          </h2>
+          <p className="mb-6 text-[1rem] leading-[1.8] text-foreground">
+            ChatVector uses a <em>Strategy Pattern</em> for database access. The application code
+            never talks to a specific database driver directly — it calls a common interface backed
+            by either <strong>SQLAlchemy</strong> (local / Docker) or{" "}
+            <strong>Supabase</strong> (hosted production). Swapping backends requires only an
+            environment variable change.
+          </p>
 
-      {/* Dev vs Prod table */}
-      <div className="overflow-x-auto mb-10">
-        <table className="w-full bg-surface border border-border rounded-xl text-[0.9rem] text-foreground">
-          <thead>
-            <tr>
-              {["", "Development", "Production"].map((h) => (
-                <th
-                  key={h}
-                  className="px-4 py-3 text-left border-b border-border font-semibold"
-                >
-                  {h}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {[
-              ["Backend", "SQLAlchemy + Docker Postgres", "Supabase (managed Postgres)"],
-              ["Vector store", "pgvector via Docker", "pgvector via Supabase"],
-              ["Setup", "docker compose up", "Set SUPABASE_URL + SUPABASE_KEY"],
-              ["Cost", "Free", "Supabase free tier / paid"],
-              ["Best for", "Local dev & CI", "Deployed / shared environments"],
-            ].map(([label, dev, prod]) => (
-              <tr key={label}>
-                <td className="px-4 py-3 border-b border-border font-mono text-[0.8rem] text-accent">
-                  {label}
-                </td>
-                <td className="px-4 py-3 border-b border-border">{dev}</td>
-                <td className="px-4 py-3 border-b border-border">{prod}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+          <div className="mb-10 overflow-x-auto">
+            <table className="w-full rounded-xl border border-border bg-surface text-[0.9rem] text-foreground">
+              <thead>
+                <tr>
+                  {["", "Development", "Production"].map((h) => (
+                    <th
+                      key={h}
+                      className="border-b border-border px-4 py-3 text-left font-semibold"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ["Backend", "SQLAlchemy + Docker Postgres", "Supabase (managed Postgres)"],
+                  ["Vector store", "pgvector via Docker", "pgvector via Supabase"],
+                  ["Setup", "docker compose up", "Set SUPABASE_URL + SUPABASE_KEY"],
+                  ["Cost", "Free", "Supabase free tier / paid"],
+                  ["Best for", "Local dev & CI", "Deployed / shared environments"],
+                ].map(([label, dev, prod]) => (
+                  <tr key={label}>
+                    <td className="border-b border-border px-4 py-3 font-mono text-[0.8rem] text-accent">
+                      {label}
+                    </td>
+                    <td className="border-b border-border px-4 py-3">{dev}</td>
+                    <td className="border-b border-border px-4 py-3">{prod}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-      {/* 03 — Retry Logic */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        03 — Reliability
-      </h2>
-      <h3 className="text-lg font-semibold text-foreground mb-3">
-        Retry Logic
-      </h3>
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-4">
-        Database writes in the ingestion pipeline — particularly{" "}
-        <code className="px-1 py-0.5 bg-surface border border-border rounded font-mono text-[0.85em]">
-          insert_chunk
-        </code>{" "}
-        — use explicit retry logic with exponential back-off to handle transient failures.
-        This is a blocking dependency for batch ingestion and validation features (see{" "}
-        <a
-          href="https://github.com/chatvector-ai/chatvector-ai/issues/44"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-accent hover:text-accent/80"
-        >
-          #44
-        </a>
-        ).
-      </p>
-      <pre className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-5 overflow-x-auto mb-10 text-foreground leading-[1.7]">{`for attempt in range(MAX_RETRIES):
+        <section>
+          <Kicker variant="numbered" spacing="sm">
+            03 — Reliability
+          </Kicker>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Retry Logic</h2>
+          <p className="mb-4 text-[1rem] leading-[1.8] text-foreground">
+            Database writes in the ingestion pipeline — particularly{" "}
+            <code className="rounded border border-border bg-surface px-1 py-0.5 font-mono text-[0.85em]">
+              insert_chunk
+            </code>{" "}
+            — use explicit retry logic with exponential back-off to handle transient failures.
+            This is a blocking dependency for batch ingestion and validation features (see{" "}
+            <a
+              href="https://github.com/chatvector-ai/chatvector-ai/issues/44"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:text-accent/80"
+            >
+              #44
+            </a>
+            ).
+          </p>
+          <pre className="mb-10 overflow-x-auto rounded-xl border border-border bg-surface p-5 font-mono text-[0.82rem] leading-[1.7] text-foreground">{`for attempt in range(MAX_RETRIES):
     try:
         insert_chunk(chunk)
         break
     except TransientDBError:
         wait(backoff(attempt))
         continue`}</pre>
+        </section>
 
-      {/* 04 — Ingestion Queue */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        04 — Ingestion
-      </h2>
-      <h3 className="text-lg font-semibold text-foreground mb-3">
-        Ingestion Queue
-      </h3>
-      <div className="bg-surface border border-border border-l-[3px] border-l-accent p-4 mb-10">
-        <p className="text-foreground text-[1rem] leading-[1.8]">
-          Documents are parsed, chunked, and embedded asynchronously via an{" "}
-          <code className="px-1 py-0.5 bg-surface border border-border rounded font-mono text-[0.85em]">
-            asyncio.Queue
-          </code>{" "}
-          with a background worker pool, token bucket rate limiter, exponential backoff with
-          jitter, and a dead-letter queue for failed jobs. A Redis replacement is planned for
-          Phase 2 to support higher-throughput batch processing at scale.
-        </p>
-      </div>
+        <section>
+          <Kicker variant="numbered" spacing="sm">
+            04 — Ingestion
+          </Kicker>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Ingestion Queue</h2>
+          <div className="mb-10 border border-border border-l-[3px] border-l-accent bg-surface p-4">
+            <p className="text-[1rem] leading-[1.8] text-foreground">
+              Documents are parsed, chunked, and embedded asynchronously via an{" "}
+              <code className="rounded border border-border bg-surface px-1 py-0.5 font-mono text-[0.85em]">
+                asyncio.Queue
+              </code>{" "}
+              with a background worker pool, token bucket rate limiter, exponential backoff with
+              jitter, and a dead-letter queue for failed jobs. A Redis replacement is planned for
+              Phase 2 to support higher-throughput batch processing at scale.
+            </p>
+          </div>
+        </section>
 
-      {/* 05 — Vector Search */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        05 — Vector Search
-      </h2>
-      <h3 className="text-lg font-semibold text-foreground mb-3">
-        Vector Search Design
-      </h3>
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-4">
-        Similarity search is handled by <strong>pgvector</strong> running inside Postgres — no
-        separate vector database required. Embeddings are stored alongside document metadata in
-        the same schema, keeping the operational footprint minimal.
-      </p>
-      <pre className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-5 overflow-x-auto mb-10 text-foreground leading-[1.7]">{`-- Schema overview (simplified)
+        <section>
+          <Kicker variant="numbered" spacing="sm">
+            05 — Vector Search
+          </Kicker>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Vector Search Design</h2>
+          <p className="mb-4 text-[1rem] leading-[1.8] text-foreground">
+            Similarity search is handled by <strong>pgvector</strong> running inside Postgres — no
+            separate vector database required. Embeddings are stored alongside document metadata in
+            the same schema, keeping the operational footprint minimal.
+          </p>
+          <pre className="mb-10 overflow-x-auto rounded-xl border border-border bg-surface p-5 font-mono text-[0.82rem] leading-[1.7] text-foreground">{`-- Schema overview (simplified)
 chunks (
   id          UUID PRIMARY KEY,
   document_id UUID REFERENCES documents(id),
@@ -162,45 +156,45 @@ SELECT content
 FROM   chunks
 ORDER  BY embedding <-> $query_vector
 LIMIT  $top_k;`}</pre>
+        </section>
 
-      {/* 06 — Design Principles */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        06 — Philosophy
-      </h2>
-      <h3 className="text-lg font-semibold text-foreground mb-4">
-        Design Principles
-      </h3>
-      <div className="space-y-3 mb-10">
-        {[
-          {
-            title: "Opinionated over configurable",
-            body: "One well-lit path for document Q&A rather than an n-dimensional framework.",
-          },
-          {
-            title: "Batteries included",
-            body: "Logging, testing, retry logic, and a clean API ship out of the box.",
-          },
-          {
-            title: "Minimal operational surface",
-            body: "pgvector in Postgres means one fewer service to run in production.",
-          },
-          {
-            title: "Contributor-friendly",
-            body: "Clear issue labels, a single docker compose command, and good-first-issue tags keep onboarding friction low.",
-          },
-        ].map(({ title, body }) => (
-          <div
-            key={title}
-            className="bg-surface border border-border rounded-xl px-5 py-4"
-          >
-            <p className="font-semibold text-foreground text-[0.95rem] mb-1">{title}</p>
-            <p className="text-foreground text-[0.92rem] leading-[1.7]">{body}</p>
+        <section>
+          <Kicker variant="numbered" spacing="sm">
+            06 — Philosophy
+          </Kicker>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Design Principles</h2>
+          <div className="mb-10 space-y-3">
+            {[
+              {
+                title: "Opinionated over configurable",
+                body: "One well-lit path for document Q&A rather than an n-dimensional framework.",
+              },
+              {
+                title: "Batteries included",
+                body: "Logging, testing, retry logic, and a clean API ship out of the box.",
+              },
+              {
+                title: "Minimal operational surface",
+                body: "pgvector in Postgres means one fewer service to run in production.",
+              },
+              {
+                title: "Contributor-friendly",
+                body: "Clear issue labels, a single docker compose command, and good-first-issue tags keep onboarding friction low.",
+              },
+            ].map(({ title, body }) => (
+              <div
+                key={title}
+                className="rounded-xl border border-border bg-surface px-5 py-4"
+              >
+                <p className="mb-1 text-[0.95rem] font-semibold text-foreground">{title}</p>
+                <p className="text-[0.92rem] leading-[1.7] text-foreground">{body}</p>
+              </div>
+            ))}
           </div>
-        ))}
+        </section>
       </div>
 
-      {/* Footer */}
-      <p className="text-foreground text-[1rem] leading-[1.8] border-t border-border pt-6">
+      <p className="border-t border-border pt-6 text-[1rem] leading-[1.8] text-foreground">
         For full architecture details, see{" "}
         <a
           href="https://github.com/chatvector-ai/chatvector-ai/blob/main/ARCHITECTURE.md"
@@ -212,6 +206,6 @@ LIMIT  $top_k;`}</pre>
         </a>
         .
       </p>
-    </div>
+    </DocLayout>
   );
 }

--- a/frontend-demo/app/components/DocLayout.tsx
+++ b/frontend-demo/app/components/DocLayout.tsx
@@ -1,0 +1,13 @@
+interface DocLayoutProps {
+  children: React.ReactNode;
+}
+
+export function DocLayout({ children }: DocLayoutProps) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <main className="mx-auto w-full max-w-[720px] px-6 py-16 md:py-20">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/frontend-demo/app/components/DocLayout.tsx
+++ b/frontend-demo/app/components/DocLayout.tsx
@@ -4,10 +4,8 @@ interface DocLayoutProps {
 
 export function DocLayout({ children }: DocLayoutProps) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <main className="mx-auto w-full max-w-[720px] px-6 py-16 md:py-20">
-        {children}
-      </main>
+    <div className="mx-auto w-full max-w-[720px] px-6 py-16 md:py-20">
+      {children}
     </div>
   );
 }

--- a/frontend-demo/app/components/DocPageHeader.tsx
+++ b/frontend-demo/app/components/DocPageHeader.tsx
@@ -1,0 +1,27 @@
+import { Kicker } from "@/app/components/Kicker";
+
+interface DocPageHeaderProps {
+  kicker: string;
+  title: string;
+  description?: string;
+}
+
+export function DocPageHeader({
+  kicker,
+  title,
+  description,
+}: DocPageHeaderProps) {
+  return (
+    <header className="space-y-4">
+      <Kicker spacing="sm">{kicker}</Kicker>
+      <h1 className="text-3xl font-bold tracking-tight text-foreground">
+        {title}
+      </h1>
+      {description && (
+        <p className="text-lg leading-relaxed text-foreground/90">
+          {description}
+        </p>
+      )}
+    </header>
+  );
+}

--- a/frontend-demo/app/components/ErrorState.tsx
+++ b/frontend-demo/app/components/ErrorState.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import Image from "next/image";
+import { Kicker } from "@/app/components/Kicker";
 
 type Props = {
-  kicker?: string; // defaults to "// error"
+  kicker?: string; // label after // (defaults to "error")
   heading: string;
   message: string;
   onRetry?: () => void; // renders a retry button when provided
 };
 
 export default function ErrorState({
-  kicker = "// error",
+  kicker = "error",
   heading,
   message,
   onRetry,
@@ -34,9 +35,9 @@ export default function ErrorState({
         priority
         className="hidden [[data-theme=light]_&]:block"
       />
-      <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
+      <Kicker spacing="sm" className="!mb-0">
         {kicker}
-      </p>
+      </Kicker>
       <h2 className="text-foreground font-semibold text-xl">{heading}</h2>
       <p className="text-muted text-[1rem]">{message}</p>
       {onRetry && (

--- a/frontend-demo/app/components/Kicker.tsx
+++ b/frontend-demo/app/components/Kicker.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+interface KickerProps {
+  children: React.ReactNode;
+  variant?: "comment" | "numbered";
+  spacing?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export function Kicker({
+  children,
+  variant = "comment",
+  spacing = "md",
+  className,
+}: KickerProps) {
+  const spacingClasses = {
+    sm: "mb-2",
+    md: "mb-3",
+    lg: "mb-4",
+  };
+
+  const content = variant === "comment" ? `// ${children}` : children;
+
+  return (
+    <p
+      className={cn(
+        "font-mono text-xs uppercase tracking-[2px] text-accent",
+        spacingClasses[spacing],
+        className,
+      )}
+    >
+      {content}
+    </p>
+  );
+}

--- a/frontend-demo/app/components/Kicker.tsx
+++ b/frontend-demo/app/components/Kicker.tsx
@@ -24,7 +24,7 @@ export function Kicker({
   return (
     <p
       className={cn(
-        "font-mono text-xs uppercase tracking-[2px] text-accent",
+        "font-mono text-sm uppercase tracking-[2px] text-accent",
         spacingClasses[spacing],
         className,
       )}

--- a/frontend-demo/app/components/Kicker.tsx
+++ b/frontend-demo/app/components/Kicker.tsx
@@ -1,5 +1,11 @@
 import { cn } from "@/lib/utils";
 
+const SPACING_CLASSES = {
+  sm: "mb-2",
+  md: "mb-3",
+  lg: "mb-4",
+} as const;
+
 interface KickerProps {
   children: React.ReactNode;
   variant?: "comment" | "numbered";
@@ -13,11 +19,6 @@ export function Kicker({
   spacing = "md",
   className,
 }: KickerProps) {
-  const spacingClasses = {
-    sm: "mb-2",
-    md: "mb-3",
-    lg: "mb-4",
-  };
 
   const content = variant === "comment" ? `// ${children}` : children;
 
@@ -25,7 +26,7 @@ export function Kicker({
     <p
       className={cn(
         "font-mono text-sm uppercase tracking-[2px] text-accent",
-        spacingClasses[spacing],
+        SPACING_CLASSES[spacing],
         className,
       )}
     >

--- a/frontend-demo/app/components/home/Developers.tsx
+++ b/frontend-demo/app/components/home/Developers.tsx
@@ -1,3 +1,4 @@
+import { Kicker } from "@/app/components/Kicker";
 import { SYNTAX } from "../../lib/constants";
 
 const DEV_POINTS = [
@@ -65,9 +66,7 @@ export default function Developers() {
   return (
     <section id="developers" className="bg-background px-8 py-24">
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-4 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-          {"// built for developers"}
-        </p>
+        <Kicker spacing="lg">for developers</Kicker>
         <h2 className="mb-4 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-foreground">
           Designed for people who
           <br />

--- a/frontend-demo/app/components/home/Features.tsx
+++ b/frontend-demo/app/components/home/Features.tsx
@@ -1,3 +1,5 @@
+import { Kicker } from "@/app/components/Kicker";
+
 const FEATURES = [
   {
     icon: "⬆",
@@ -94,9 +96,7 @@ export default function Features() {
   return (
     <section id="features" className="bg-surface px-8 py-24">
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-4 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-          {"// capabilities"}
-        </p>
+        <Kicker spacing="lg">features</Kicker>
         <h2 className="mb-12 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-foreground">
           Everything you need.
           <br />

--- a/frontend-demo/app/components/home/WhatIs.tsx
+++ b/frontend-demo/app/components/home/WhatIs.tsx
@@ -1,3 +1,5 @@
+import { Kicker } from "@/app/components/Kicker";
+
 function PipelineStep({
   num,
   title,
@@ -55,9 +57,7 @@ export default function WhatIs() {
   return (
     <section id="about" className="bg-background px-8 py-24">
       <div className="mx-auto max-w-[1100px]">
-        <p className="mb-4 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-          {"// what is chatvector"}
-        </p>
+        <Kicker spacing="lg">what is chatvector</Kicker>
         <h2 className="mb-5 text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold leading-tight tracking-[-0.8px] text-foreground">
           RAG that&apos;s sharp, fast,
           <br />

--- a/frontend-demo/app/contributing/page.tsx
+++ b/frontend-demo/app/contributing/page.tsx
@@ -1,124 +1,122 @@
+import { DocLayout } from "@/app/components/DocLayout";
+import { DocPageHeader } from "@/app/components/DocPageHeader";
+import { Kicker } from "@/app/components/Kicker";
+
 export default function ContributingPage() {
   return (
-    <div className="max-w-[720px] mx-auto px-4 py-10">
-      
-      <h1 className="text-3xl font-bold mb-6 text-foreground">
-        Contributing
-      </h1>
+    <DocLayout>
+      <DocPageHeader
+        kicker="contributing"
+        title="Contributing to ChatVector"
+        description="Learn how to get started with contributing to ChatVector and find ways to get involved."
+      />
 
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-6">
-        Learn how to get started with contributing to ChatVector and find ways to get involved.
-      </p>
+      <div className="mt-10 space-y-10">
+        <section>
+          <Kicker spacing="sm">finding issues</Kicker>
+          <div className="mb-6 border border-border border-l-[3px] border-l-accent bg-surface p-4">
+            <p className="text-[1rem] leading-[1.8] text-foreground">
+              Look for issues labeled{" "}
+              <code className="rounded border border-border bg-surface px-1 py-0.5">
+                good first issue
+              </code>{" "}
+              to get started easily. You can also explore the project board to see what is currently being worked on or find tasks that match your interests.
+            </p>
+          </div>
+        </section>
 
-      {/* Finding Issues */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        Finding Issues
-      </h2>
-      <div className="bg-surface border border-border border-l-[3px] border-l-accent p-4 mb-6">
-        <p className="text-foreground text-[1rem] leading-[1.8]">
-          Look for issues labeled{" "}
-          <code className="px-1 py-0.5 bg-surface border border-border rounded">
-            good first issue
-          </code>{" "}
-          to get started easily. You can also explore the project board to see what is currently being worked on or find tasks that match your interests.
-        </p>
+        <section>
+          <Kicker spacing="sm">branch & commit naming</Kicker>
+          <div className="mb-6 border border-border border-l-[3px] border-l-accent bg-surface p-4">
+            <p className="text-[1rem] leading-[1.8] text-foreground">
+              Use a clear naming convention like{" "}
+              <code className="rounded border border-border bg-surface px-1 py-0.5">
+                type/description
+              </code>
+              . Examples include{" "}
+              <code className="rounded border border-border bg-surface px-1 py-0.5">
+                feat/add-feature
+              </code>
+              ,{" "}
+              <code className="rounded border border-border bg-surface px-1 py-0.5">
+                fix/bug-fix
+              </code>
+              , and{" "}
+              <code className="rounded border border-border bg-surface px-1 py-0.5">
+                docs/update-readme
+              </code>
+              . Keep your commits focused and descriptive.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <Kicker spacing="sm">pull request process</Kicker>
+          <div className="mb-6 border border-border border-l-[3px] border-l-accent bg-surface p-4">
+            <p className="text-[1rem] leading-[1.8] text-foreground">
+              Create a new branch, implement your changes, and open a pull request from your fork to the main repository.
+              Make sure to clearly describe what your PR does, how it was tested, and follow the checklist before submitting.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <Kicker spacing="sm">helpful links</Kicker>
+          <ul className="mb-6 space-y-2 text-foreground">
+            <li>
+              <a
+                href="https://www.loom.com/share/c41bdbff541f47d49efcb48920cba382"
+                className="text-accent hover:text-accent/80"
+              >
+                Loom Contributor Video
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/chatvector-ai/chatvector-ai/discussions"
+                className="text-accent hover:text-accent/80"
+              >
+                GitHub Discussions
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/chatvector-ai/chatvector-ai/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+                className="text-accent hover:text-accent/80"
+              >
+                Good First Issues
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/chatvector-ai/chatvector-ai/projects"
+                className="text-accent hover:text-accent/80"
+              >
+                Project Board
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/chatvector-ai/chatvector-ai/blob/main/README.md"
+                className="text-accent hover:text-accent/80"
+              >
+                Project README
+              </a>
+            </li>
+          </ul>
+        </section>
       </div>
 
-      {/* Branch Naming */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        Branch & Commit Naming
-      </h2>
-      <div className="bg-surface border border-border border-l-[3px] border-l-accent p-4 mb-6">
-        <p className="text-foreground text-[1rem] leading-[1.8]">
-          Use a clear naming convention like{" "}
-          <code className="px-1 py-0.5 bg-surface border border-border rounded">
-            type/description
-          </code>
-          . Examples include{" "}
-          <code className="px-1 py-0.5 bg-surface border border-border rounded">
-            feat/add-feature
-          </code>
-          ,{" "}
-          <code className="px-1 py-0.5 bg-surface border border-border rounded">
-            fix/bug-fix
-          </code>
-          , and{" "}
-          <code className="px-1 py-0.5 bg-surface border border-border rounded">
-            docs/update-readme
-          </code>
-          . Keep your commits focused and descriptive.
-        </p>
-      </div>
-
-      {/* PR Process */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        Pull Request Process
-      </h2>
-      <div className="bg-surface border border-border border-l-[3px] border-l-accent p-4 mb-6">
-        <p className="text-foreground text-[1rem] leading-[1.8]">
-          Create a new branch, implement your changes, and open a pull request from your fork to the main repository. 
-          Make sure to clearly describe what your PR does, how it was tested, and follow the checklist before submitting.
-        </p>
-      </div>
-
-      {/* Links */}
-      <h2 className="mt-8 mb-2 font-mono text-[0.78rem] uppercase tracking-[2px] text-accent">
-        Helpful Links
-      </h2>
-      <ul className="mb-6 space-y-2">
-        <li>
-          <a 
-            href="https://www.loom.com/share/c41bdbff541f47d49efcb48920cba382" 
-            className="text-accent hover:text-accent/80"
-          >
-            Loom Contributor Video
-          </a>
-        </li>
-        <li>
-          <a 
-            href="https://github.com/chatvector-ai/chatvector-ai/discussions" 
-            className="text-accent hover:text-accent/80"
-          >
-            GitHub Discussions
-          </a>
-        </li>
-        <li>
-          <a 
-            href="https://github.com/chatvector-ai/chatvector-ai/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22" 
-            className="text-accent hover:text-accent/80"
-          >
-            Good First Issues
-          </a>
-        </li>
-        <li>
-          <a 
-            href="https://github.com/chatvector-ai/chatvector-ai/projects" 
-            className="text-accent hover:text-accent/80"
-          >
-            Project Board
-          </a>
-        </li>
-        <li>
-          <a 
-            href="https://github.com/chatvector-ai/chatvector-ai/blob/main/README.md" 
-            className="text-accent hover:text-accent/80"
-          >
-            Project README
-          </a>
-        </li>
-      </ul>
-
-      {/* Footer */}
-      <p className="text-foreground text-[1rem] leading-[1.8]">
+      <p className="text-[1rem] leading-[1.8] text-foreground">
         For the full contribution guide, see{" "}
-        <a 
+        <a
           href="https://github.com/chatvector-ai/chatvector-ai/blob/main/CONTRIBUTING.md"
           className="text-accent hover:text-accent/80"
         >
           CONTRIBUTING.md on GitHub
-        </a>.
+        </a>
+        .
       </p>
-
-    </div>
+    </DocLayout>
   );
 }

--- a/frontend-demo/app/contributing/page.tsx
+++ b/frontend-demo/app/contributing/page.tsx
@@ -62,11 +62,11 @@ export default function ContributingPage() {
 
         <section>
           <Kicker spacing="sm">helpful links</Kicker>
-          <ul className="mb-6 space-y-2 text-foreground">
+          <ul className="mb-6 space-y-2">
             <li>
               <a
                 href="https://www.loom.com/share/c41bdbff541f47d49efcb48920cba382"
-                className="text-accent hover:text-accent/80"
+                className="text-muted transition-colors hover:text-foreground"
               >
                 Loom Contributor Video
               </a>
@@ -74,7 +74,7 @@ export default function ContributingPage() {
             <li>
               <a
                 href="https://github.com/chatvector-ai/chatvector-ai/discussions"
-                className="text-accent hover:text-accent/80"
+                className="text-muted transition-colors hover:text-foreground"
               >
                 GitHub Discussions
               </a>
@@ -82,7 +82,7 @@ export default function ContributingPage() {
             <li>
               <a
                 href="https://github.com/chatvector-ai/chatvector-ai/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
-                className="text-accent hover:text-accent/80"
+                className="text-muted transition-colors hover:text-foreground"
               >
                 Good First Issues
               </a>
@@ -90,7 +90,7 @@ export default function ContributingPage() {
             <li>
               <a
                 href="https://github.com/chatvector-ai/chatvector-ai/projects"
-                className="text-accent hover:text-accent/80"
+                className="text-muted transition-colors hover:text-foreground"
               >
                 Project Board
               </a>
@@ -98,7 +98,7 @@ export default function ContributingPage() {
             <li>
               <a
                 href="https://github.com/chatvector-ai/chatvector-ai/blob/main/README.md"
-                className="text-accent hover:text-accent/80"
+                className="text-muted transition-colors hover:text-foreground"
               >
                 Project README
               </a>

--- a/frontend-demo/app/contributors/page.tsx
+++ b/frontend-demo/app/contributors/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import ErrorState from "../components/ErrorState";
+import { DocLayout } from "@/app/components/DocLayout";
+import { DocPageHeader } from "@/app/components/DocPageHeader";
 
 type Contributor = {
   login: string;
@@ -27,7 +29,6 @@ export default function ContributorsPage() {
         return res.json();
       })
       .then((data) => {
-        // sort explicitly (even though API already does)
         const sorted = data.sort(
           (a: Contributor, b: Contributor) => b.contributions - a.contributions,
         );
@@ -45,26 +46,23 @@ export default function ContributorsPage() {
   }, [fetchContributors]);
 
   return (
-    <div className="max-w-[720px] mx-auto px-4 py-10">
-      <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-2">
-        {"// thanks"}
-      </p>
-      <h1 className="text-3xl font-bold mb-4 text-foreground">Contributors</h1>
-      <p className="text-foreground text-[1rem] leading-[1.8] mb-8">
-        A special thanks to everyone who has contributed code, documentation,
-        ideas, or feedback. This project is shaped by the community.
-      </p>
+    <DocLayout>
+      <DocPageHeader
+        kicker="thanks"
+        title="Contributors"
+        description="A special thanks to everyone who has contributed code, documentation, ideas, or feedback. This project is shaped by the community."
+      />
 
       {loading && (
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="mt-8 grid grid-cols-2 gap-4 md:grid-cols-3">
           {Array.from({ length: 9 }).map((_, i) => (
             <div
               key={i}
-              className="animate-pulse bg-surface border border-border rounded-lg p-4 flex flex-col items-center gap-3"
+              className="flex animate-pulse flex-col items-center gap-3 rounded-lg border border-border bg-surface p-4"
             >
-              <div className="w-16 h-16 rounded-full bg-border" />
-              <div className="h-3 w-36 md:w-48 rounded bg-border" />
-              <div className="h-3 w-24 md:w-28 rounded bg-border" />
+              <div className="h-16 w-16 rounded-full bg-border" />
+              <div className="h-3 w-36 rounded bg-border md:w-48" />
+              <div className="h-3 w-24 rounded bg-border md:w-28" />
             </div>
           ))}
         </div>
@@ -81,32 +79,32 @@ export default function ContributorsPage() {
       )}
 
       {!loading && !error && (
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="mt-8 grid grid-cols-2 gap-4 md:grid-cols-3">
           {contributors.map((c) => (
             <a
               key={c.login}
               href={c.html_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="bg-surface border border-border p-4 rounded-lg flex flex-col items-center hover:border-accent hover:scale-[1.02] transition"
+              className="flex flex-col items-center rounded-lg border border-border bg-surface p-4 transition hover:scale-[1.02] hover:border-accent"
             >
               <Image
                 src={c.avatar_url}
                 alt={c.login}
                 width={64}
                 height={64}
-                className="rounded-full mb-3"
+                className="mb-3 rounded-full"
               />
 
               <p className="font-mono text-accent">@{c.login}</p>
 
-              <p className="text-muted text-sm">
+              <p className="text-sm text-foreground/80">
                 {c.contributions} contributions
               </p>
             </a>
           ))}
         </div>
       )}
-    </div>
+    </DocLayout>
   );
 }

--- a/frontend-demo/app/getting-started/page.tsx
+++ b/frontend-demo/app/getting-started/page.tsx
@@ -1,6 +1,8 @@
-const kickerClass =
-  "font-mono text-[0.78rem] uppercase tracking-[2px] text-accent";
-const bodyClass = "text-muted text-[1rem] leading-[1.8]";
+import { DocLayout } from "@/app/components/DocLayout";
+import { DocPageHeader } from "@/app/components/DocPageHeader";
+import { Kicker } from "@/app/components/Kicker";
+
+const bodyClass = "text-foreground/90 text-[1rem] leading-[1.8]";
 const cardClass =
   "rounded-xl border border-border bg-surface p-6 transition-colors hover:border-accent/40";
 const codeClass =
@@ -8,36 +10,30 @@ const codeClass =
 
 export default function GettingStartedPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <main className="mx-auto flex w-full max-w-[720px] flex-col gap-16 px-6 pb-24 pt-16">
-        <section className="space-y-6">
-          <p className={`${kickerClass} block mb-4`}>
-            {"// getting started"}
-          </p>
-          <h1 className="text-3xl font-bold leading-[1.1] tracking-[-1px]">
-            Run ChatVector locally in minutes.
-          </h1>
-          <p className={bodyClass}>
-            ChatVector is a backend-first RAG engine for document intelligence.
-            This page summarizes the fastest path to run the API and the demo UI
-            on your machine.
-          </p>
+    <DocLayout>
+      <div className="flex flex-col gap-16">
+        <div className="space-y-6">
+          <DocPageHeader
+            kicker="getting started"
+            title="Run ChatVector locally in minutes."
+            description="ChatVector is a backend-first RAG engine for document intelligence. This page summarizes the fastest path to run the API and the demo UI on your machine."
+          />
           <div className={cardClass}>
-            <p className="text-foreground text-[1rem] font-medium">
+            <p className="text-[1rem] font-medium text-foreground">
               What you will get
             </p>
-            <ul className="mt-4 space-y-3 text-muted text-[0.98rem] leading-[1.7]">
+            <ul className="mt-4 space-y-3 text-[0.98rem] leading-[1.7] text-foreground/90">
               <li>FastAPI backend with RAG ingestion and retrieval.</li>
               <li>PostgreSQL + pgvector for semantic search.</li>
               <li>Next.js demo UI for uploads, chat, and citations.</li>
             </ul>
           </div>
-        </section>
+        </div>
 
         <section className="space-y-6">
-          <p className={`${kickerClass} block mb-4`}>{"// prerequisites"}</p>
+          <Kicker spacing="lg">prerequisites</Kicker>
           <div className={cardClass}>
-            <ul className="space-y-3 text-muted text-[0.98rem] leading-[1.7]">
+            <ul className="space-y-3 text-[0.98rem] leading-[1.7] text-foreground/90">
               <li>Docker + Docker Compose installed.</li>
               <li>Google AI Studio API key for embeddings + LLM.</li>
               <li>Node.js 18+ (for the demo UI).</li>
@@ -46,11 +42,11 @@ export default function GettingStartedPage() {
         </section>
 
         <section className="space-y-6">
-          <p className={`${kickerClass} block mb-4`}>{"// quick setup"}</p>
+          <Kicker spacing="lg">quick setup</Kicker>
           <div className={cardClass}>
-            <ol className="space-y-6 text-muted text-[0.98rem] leading-[1.7]">
+            <ol className="space-y-6 text-[0.98rem] leading-[1.7] text-foreground/90">
               <li>
-                <span className="text-foreground font-medium">Star the repo.</span>{" "}
+                <span className="font-medium text-foreground">Star the repo.</span>{" "}
                 <a
                   className="text-accent underline decoration-transparent hover:decoration-accent"
                   href="https://github.com/chatvector-ai/chatvector-ai"
@@ -62,18 +58,18 @@ export default function GettingStartedPage() {
                 ⭐
               </li>
               <li>
-                <span className="text-foreground font-medium">
+                <span className="font-medium text-foreground">
                   Create the backend environment file.
                 </span>
                 <div className="mt-3">
                   <pre className={codeClass}>cp backend/.env.example backend/.env</pre>
                 </div>
-                <p className="mt-3 text-muted text-[0.98rem] leading-[1.7]">
+                <p className="mt-3 text-[0.98rem] leading-[1.7] text-foreground/80">
                   Edit the file and set <span className="text-foreground">GEN_AI_KEY</span>.
                 </p>
               </li>
               <li>
-                <span className="text-foreground font-medium">
+                <span className="font-medium text-foreground">
                   Create the frontend environment file.
                 </span>
                 <div className="mt-3">
@@ -81,12 +77,12 @@ export default function GettingStartedPage() {
                     {`NEXT_PUBLIC_API_URL=http://localhost:8000`}
                   </pre>
                 </div>
-                <p className="mt-3 text-muted text-[0.98rem] leading-[1.7]">
+                <p className="mt-3 text-[0.98rem] leading-[1.7] text-foreground/80">
                   Save this as <span className="text-foreground">frontend-demo/.env.local</span>.
                 </p>
               </li>
               <li>
-                <span className="text-foreground font-medium">
+                <span className="font-medium text-foreground">
                   Launch the backend stack.
                 </span>
                 <div className="mt-3">
@@ -94,7 +90,7 @@ export default function GettingStartedPage() {
                 </div>
               </li>
               <li>
-                <span className="text-foreground font-medium">
+                <span className="font-medium text-foreground">
                   Start the frontend demo.
                 </span>
                 <div className="mt-3 space-y-2">
@@ -102,7 +98,7 @@ export default function GettingStartedPage() {
                   <pre className={codeClass}>npm install</pre>
                   <pre className={codeClass}>npm run dev</pre>
                 </div>
-                <p className="mt-3 text-muted text-[0.98rem] leading-[1.7]">
+                <p className="mt-3 text-[0.98rem] leading-[1.7] text-foreground/80">
                   Frontend runs at <span className="text-foreground">http://localhost:3000</span>.
                 </p>
               </li>
@@ -111,14 +107,14 @@ export default function GettingStartedPage() {
         </section>
 
         <section className="space-y-6">
-          <p className={`${kickerClass} block mb-4`}>{"// test the api"}</p>
+          <Kicker spacing="lg">test the api</Kicker>
           <p className={bodyClass}>
             Once the containers are up, hit the root endpoint and open Swagger
             UI. Then try the three core endpoints to upload a document, check
             status, and ask questions.
           </p>
           <div className={cardClass}>
-            <div className="space-y-3 text-muted text-[0.98rem] leading-[1.7]">
+            <div className="space-y-3 text-[0.98rem] leading-[1.7] text-foreground/90">
               <p>
                 Root: <span className="text-foreground">http://localhost:8000</span>
               </p>
@@ -136,10 +132,10 @@ export default function GettingStartedPage() {
         </section>
 
         <section className="space-y-6">
-          <p className={`${kickerClass} block mb-4`}>{"// docker commands"}</p>
+          <Kicker spacing="lg">docker commands</Kicker>
           <div className={cardClass}>
             <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-left text-[0.95rem] text-muted">
+              <table className="w-full border-collapse text-left text-[0.95rem] text-foreground/90">
                 <thead>
                   <tr className="border-b border-border">
                     <th className="py-3 pr-4 font-medium text-foreground">Command</th>
@@ -151,31 +147,31 @@ export default function GettingStartedPage() {
                     <td className="py-3 pr-4 font-mono text-foreground">
                       docker compose up --build
                     </td>
-                    <td className="py-3">Start API + database</td>
+                    <td className="py-3 text-foreground/80">Start API + database</td>
                   </tr>
                   <tr className="transition-colors hover:bg-accent/5">
                     <td className="py-3 pr-4 font-mono text-foreground">
                       docker compose down
                     </td>
-                    <td className="py-3">Stop containers</td>
+                    <td className="py-3 text-foreground/80">Stop containers</td>
                   </tr>
                   <tr className="transition-colors hover:bg-accent/5">
                     <td className="py-3 pr-4 font-mono text-foreground">
                       docker compose logs -f api
                     </td>
-                    <td className="py-3">Tail API logs</td>
+                    <td className="py-3 text-foreground/80">Tail API logs</td>
                   </tr>
                   <tr className="transition-colors hover:bg-accent/5">
                     <td className="py-3 pr-4 font-mono text-foreground">
                       docker compose up db
                     </td>
-                    <td className="py-3">Run database only</td>
+                    <td className="py-3 text-foreground/80">Run database only</td>
                   </tr>
                   <tr className="transition-colors hover:bg-accent/5">
                     <td className="py-3 pr-4 font-mono text-foreground">
                       docker compose down -v
                     </td>
-                    <td className="py-3">Stop and remove data volumes</td>
+                    <td className="py-3 text-foreground/80">Stop and remove data volumes</td>
                   </tr>
                 </tbody>
               </table>
@@ -184,7 +180,7 @@ export default function GettingStartedPage() {
         </section>
 
         <section className="space-y-6">
-          <p className={`${kickerClass} block mb-4`}>{"// next steps"}</p>
+          <Kicker spacing="lg">next steps</Kicker>
           <div className={`${cardClass} mt-2`}>
             <p className={bodyClass}>
               For full setup details, see the{" "}
@@ -200,7 +196,7 @@ export default function GettingStartedPage() {
             </p>
           </div>
         </section>
-      </main>
-    </div>
+      </div>
+    </DocLayout>
   );
 }

--- a/frontend-demo/app/not-found.tsx
+++ b/frontend-demo/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
     <main className="flex flex-col items-center justify-center min-h-screen bg-background text-center px-4">
       <div className="mb-8">
         <ErrorState
-          kicker="// 404"
+          kicker="404"
           heading="Page not found"
           message="This page doesn't exist or has been moved."
         />

--- a/frontend-demo/app/roadmap/page.tsx
+++ b/frontend-demo/app/roadmap/page.tsx
@@ -1,92 +1,89 @@
-import React from 'react';
-import Link from 'next/link';
+import Link from "next/link";
+import { DocLayout } from "@/app/components/DocLayout";
+import { DocPageHeader } from "@/app/components/DocPageHeader";
 
-// Data for the Roadmap phases
 const phases = [
   {
     number: "Phase 1",
     title: "Stabilize & Optimize Core Engine",
     status: "Complete",
     statusStyles: "bg-accent text-black",
-    description: "Core RAG backend hardened for reliability, observability, and performance. Shipped features include a robust ingestion pipeline, centralized retry logic, and built-in observability."
+    description:
+      "Core RAG backend hardened for reliability, observability, and performance. Shipped features include a robust ingestion pipeline, centralized retry logic, and built-in observability.",
   },
   {
     number: "Phase 2",
     title: "Enhance Developer Experience",
     status: "Current",
     statusStyles: "bg-blue text-white",
-    description: "Active work areas focusing on a Redis-backed durable ingestion queue, improved observability, advanced chunking strategies, and wiring up the document upload UI."
+    description:
+      "Active work areas focusing on a Redis-backed durable ingestion queue, improved observability, advanced chunking strategies, and wiring up the document upload UI.",
   },
   {
     number: "Phase 3",
     title: "Scale & Specialize",
     status: "Later",
-    statusStyles: "bg-surface text-muted border border-border",
-    description: "Long-term vision for a production-ready document intelligence platform. Future goals include authentication, multi-tenancy, specialized pipelines, and ecosystem growth."
-  }
+    statusStyles: "border border-border bg-surface text-foreground/80",
+    description:
+      "Long-term vision for a production-ready document intelligence platform. Future goals include authentication, multi-tenancy, specialized pipelines, and ecosystem growth.",
+  },
 ];
 
 export default function RoadmapPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground py-20 px-4">
-      <div className="max-w-[720px] mx-auto">
-        
-        {/* Section Kicker - Mono styled as per requirements */}
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Future Outlook
-        </p>
+    <DocLayout>
+      <DocPageHeader
+        kicker="future outlook"
+        title="Roadmap"
+        description="Phased delivery from stabilizing the core engine through developer experience and long-term scale."
+      />
 
-        <h1 className="text-4xl font-bold mb-12 tracking-tight">Project Roadmap</h1>
+      <div className="mt-12 grid gap-6">
+        {phases.map((phase, i) => (
+          <section
+            key={i}
+            className="rounded-r-xl border border-border border-l-[3px] border-l-accent bg-surface p-8 shadow-sm"
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <span className="text-[0.7rem] uppercase tracking-widest text-accent/80 font-mono">
+                {phase.number}
+              </span>
+              <span
+                className={`rounded-full px-3 py-1 text-[0.65rem] font-bold uppercase tracking-wider ${phase.statusStyles}`}
+              >
+                {phase.status}
+              </span>
+            </div>
 
-        <div className="grid gap-6">
-          {phases.map((phase, i) => (
-            <section 
-              key={i} 
-              className="bg-surface border border-border border-l-[3px] border-l-accent p-8 rounded-r-xl shadow-sm"
-            >
-              <div className="flex items-center justify-between mb-4">
-                <span className="font-mono text-[0.7rem] uppercase tracking-widest text-accent/80">
-                  {phase.number}
-                </span>
-                <span className={`px-3 py-1 rounded-full text-[0.65rem] font-bold uppercase tracking-wider ${phase.statusStyles}`}>
-                  {phase.status}
-                </span>
-              </div>
-              
-              <h3 className="text-xl font-semibold mb-3 text-foreground">
-                {phase.title}
-              </h3>
-              
-              <p className="text-muted text-[1rem] leading-[1.8]">
-                {phase.description}
-              </p>
-            </section>
-          ))}
-        </div>
+            <h2 className="mb-3 text-xl font-semibold text-foreground">{phase.title}</h2>
 
-        {/* Footer & Links Section */}
-        <div className="mt-16 pt-8 border-t border-border flex flex-col gap-6">
-          <div>
-            <p className="text-muted text-sm mb-2">Want to see what we&apos;re building right now?</p>
-            <Link 
-              href="https://github.com/orgs/chatvector-ai/projects/1" 
-              className="text-accent hover:text-accent/80 transition-colors font-medium inline-flex items-center gap-2"
-            >
-              Check the ChatVector-AI Development Board →
-            </Link>
-          </div>
-          
-          <p className="text-muted text-sm italic border-l border-border pl-4">
-            For full roadmap details, see{" "}
-            <Link 
-              href="https://github.com/chatvector-ai/chatvector-ai/blob/main/ROADMAP.md" 
-              className="underline hover:text-foreground transition-colors"
-            >
-              ROADMAP.md on GitHub
-            </Link>.
-          </p>
-        </div>
+            <p className="text-[1rem] leading-[1.8] text-foreground/90">{phase.description}</p>
+          </section>
+        ))}
       </div>
-    </div>
+
+      <div className="mt-16 flex flex-col gap-6 border-t border-border pt-8">
+        <div>
+          <p className="mb-2 text-sm text-foreground/80">Want to see what we&apos;re building right now?</p>
+          <Link
+            href="https://github.com/orgs/chatvector-ai/projects/1"
+            className="inline-flex items-center gap-2 font-medium text-accent transition-colors hover:text-accent/80"
+          >
+            Check the ChatVector-AI Development Board →
+          </Link>
+        </div>
+
+        <p className="border-l border-border pl-4 text-sm italic text-foreground/80">
+          For full roadmap details, see{" "}
+          <Link
+            href="https://github.com/chatvector-ai/chatvector-ai/blob/main/ROADMAP.md"
+            className="underline transition-colors hover:text-foreground"
+          >
+            ROADMAP.md on GitHub
+          </Link>
+          .
+        </p>
+      </div>
+    </DocLayout>
   );
 }

--- a/frontend-demo/app/sdk/page.tsx
+++ b/frontend-demo/app/sdk/page.tsx
@@ -1,59 +1,47 @@
+import { DocLayout } from "@/app/components/DocLayout";
+import { DocPageHeader } from "@/app/components/DocPageHeader";
+import { Kicker } from "@/app/components/Kicker";
+
 export default function SdkPage() {
   return (
-    <div className="max-w-[720px] mx-auto px-4 py-10 text-foreground text-[1rem] leading-[1.8]">
+    <DocLayout>
+      <div className="text-[1rem] leading-[1.8] text-foreground">
+        <DocPageHeader
+          kicker="python sdk"
+          title="ChatVector Python Client"
+          description="A lightweight Python client for uploading documents, polling ingestion status, and querying the ChatVector RAG backend over HTTP."
+        />
 
-      {/* Header */}
-      <div className="mb-12">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-3">
-          Python SDK
-        </p>
-        <h1 className="text-foreground text-3xl font-semibold mb-4">
-          ChatVector Python Client
-        </h1>
-        <p className="text-foreground text-[1rem] leading-[1.8]">
-          A lightweight Python client for uploading documents, polling ingestion status,
-          and querying the ChatVector RAG backend over HTTP.
-        </p>
-      </div>
+        <div className="mt-12 space-y-10">
+          <section>
+            <Kicker spacing="lg">requirements</Kicker>
+            <ul className="list-inside list-disc space-y-1 text-foreground/90">
+              <li>Python 3.10 or higher</li>
+              <li>
+                <code className="rounded-xl border border-border bg-surface px-2 py-0.5 font-mono text-[0.82rem]">
+                  httpx
+                </code>{" "}
+                (installed automatically as a dependency)
+              </li>
+              <li>A running ChatVector backend at a reachable URL</li>
+            </ul>
+          </section>
 
-      {/* Requirements */}
-      <section className="mb-10">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Requirements
-        </p>
-        <ul className="list-disc list-inside space-y-1">
-          <li>Python 3.10 or higher</li>
-          <li>
-            <code className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] px-2 py-0.5">
-              httpx
-            </code>{" "}
-            (installed automatically as a dependency)
-          </li>
-          <li>A running ChatVector backend at a reachable URL</li>
-        </ul>
-      </section>
+          <section>
+            <Kicker spacing="lg">installation</Kicker>
+            <p className="mb-3 text-foreground/90">Install directly from the repo:</p>
+            <pre className="overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
+              <code>pip install ./sdk/python</code>
+            </pre>
+          </section>
 
-      {/* Installation */}
-      <section className="mb-10">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Installation
-        </p>
-        <p className="mb-3">Install directly from the repo:</p>
-        <pre className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-4 overflow-x-auto">
-          <code>pip install ./sdk/python</code>
-        </pre>
-      </section>
-
-      {/* Quickstart */}
-      <section className="mb-10">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Quickstart
-        </p>
-        <p className="mb-3">
-          Upload a document, wait for ingestion to complete, then ask a question:
-        </p>
-        <pre className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-4 overflow-x-auto">
-          <code>{`from chatvector import ChatVectorClient
+          <section>
+            <Kicker spacing="lg">quickstart</Kicker>
+            <p className="mb-3 text-foreground/90">
+              Upload a document, wait for ingestion to complete, then ask a question:
+            </p>
+            <pre className="overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
+              <code>{`from chatvector import ChatVectorClient
 
 with ChatVectorClient("http://localhost:8000") as client:
     # Upload a document
@@ -70,66 +58,60 @@ with ChatVectorClient("http://localhost:8000") as client:
     # Print cited sources
     for source in answer.sources:
         print(source.file_name, source.page_number)`}</code>
-        </pre>
-      </section>
+            </pre>
+          </section>
 
-      {/* Authentication */}
-      <section className="mb-10">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Authentication
-        </p>
-        <p className="mb-3">
-          If your backend is configured with a bearer token, pass it at client initialization:
-        </p>
-        <pre className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-4 overflow-x-auto">
-          <code>{`client = ChatVectorClient(
+          <section>
+            <Kicker spacing="lg">authentication</Kicker>
+            <p className="mb-3 text-foreground/90">
+              If your backend is configured with a bearer token, pass it at client initialization:
+            </p>
+            <pre className="overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
+              <code>{`client = ChatVectorClient(
     base_url="http://localhost:8000",
     api_key="your-bearer-token"
 )`}</code>
-        </pre>
-        <p className="mt-3 text-foreground">
-          The token is optional. Omit it if your backend does not require authentication.
-        </p>
-      </section>
+            </pre>
+            <p className="mt-3 text-foreground/90">
+              The token is optional. Omit it if your backend does not require authentication.
+            </p>
+          </section>
 
-      {/* Error Handling */}
-      <section className="mb-10">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Error Handling
-        </p>
-        <p className="mb-4">
-          The client raises typed exceptions so you can handle failures cleanly:
-        </p>
-        <div className="space-y-3">
-          {[
-            {
-              name: "ChatVectorAPIError",
-              desc: "Base exception for all SDK errors. Catch this to handle any client error in one place.",
-            },
-            {
-              name: "ChatVectorAuthError",
-              desc: "Raised when the request is rejected due to missing or invalid authentication credentials.",
-            },
-            {
-              name: "ChatVectorRateLimitError",
-              desc: "Raised when the backend returns a rate limit response. Back off and retry after a delay.",
-            },
-            {
-              name: "ChatVectorTimeoutError",
-              desc: "Raised by wait_for_ready when the document does not reach a ready state within the timeout window.",
-            },
-          ].map(({ name, desc }) => (
-            <div key={name} className="flex gap-3">
-              <code className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] px-2 py-0.5 shrink-0 self-start">
-                {name}
-              </code>
-              <span>{desc}</span>
+          <section>
+            <Kicker spacing="lg">error handling</Kicker>
+            <p className="mb-4 text-foreground/90">
+              The client raises typed exceptions so you can handle failures cleanly:
+            </p>
+            <div className="space-y-3 text-foreground/90">
+              {[
+                {
+                  name: "ChatVectorAPIError",
+                  desc: "Base exception for all SDK errors. Catch this to handle any client error in one place.",
+                },
+                {
+                  name: "ChatVectorAuthError",
+                  desc: "Raised when the request is rejected due to missing or invalid authentication credentials.",
+                },
+                {
+                  name: "ChatVectorRateLimitError",
+                  desc: "Raised when the backend returns a rate limit response. Back off and retry after a delay.",
+                },
+                {
+                  name: "ChatVectorTimeoutError",
+                  desc: "Raised by wait_for_ready when the document does not reach a ready state within the timeout window.",
+                },
+              ].map(({ name, desc }) => (
+                <div key={name} className="flex gap-3">
+                  <code className="shrink-0 self-start rounded-xl border border-border bg-surface px-2 py-0.5 font-mono text-[0.82rem]">
+                    {name}
+                  </code>
+                  <span>{desc}</span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
 
-        <pre className="mt-5 bg-surface border border-border rounded-xl font-mono text-[0.82rem] p-4 overflow-x-auto">
-          <code>{`from chatvector.exceptions import (
+            <pre className="mt-5 overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
+              <code>{`from chatvector.exceptions import (
     ChatVectorAPIError,
     ChatVectorAuthError,
     ChatVectorRateLimitError,
@@ -148,63 +130,61 @@ except ChatVectorTimeoutError:
     print("Document took too long to process.")
 except ChatVectorAPIError as e:
     print("SDK error:", e)`}</code>
-        </pre>
-      </section>
+            </pre>
+          </section>
 
-      {/* Examples */}
-      <section className="mb-10">
-        <p className="font-mono text-[0.78rem] uppercase tracking-[2px] text-accent mb-4">
-          Examples
-        </p>
-        <p className="mb-4">
-          More complete usage examples are available in the repository:
-        </p>
-        <ul className="space-y-2">
-          {[
-            {
-              file: "upload_wait_chat.py",
-              href: "https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/examples/upload_wait_chat.py",
-              desc: "Full end-to-end flow: upload, wait, chat, print sources.",
-            },
-            {
-              file: "check_status.py",
-              href: "https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/examples/check_status.py",
-              desc: "Poll document status and inspect each ingestion stage.",
-            },
-            {
-              file: "batch_chat.py",
-              href: "https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/examples/batch_chat.py",
-              desc: "Send multiple questions against the same document in sequence.",
-            },
-          ].map(({ file, href, desc }) => (
-            <li key={file} className="flex gap-3">
-              <a
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-surface border border-border rounded-xl font-mono text-[0.82rem] px-2 py-0.5 shrink-0 self-start text-accent underline underline-offset-4 hover:opacity-80 transition-opacity"
-              >
-                {file}
-              </a>
-              <span>{desc}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
+          <section>
+            <Kicker spacing="lg">examples</Kicker>
+            <p className="mb-4 text-foreground/90">
+              More complete usage examples are available in the repository:
+            </p>
+            <ul className="space-y-2 text-foreground/90">
+              {[
+                {
+                  file: "upload_wait_chat.py",
+                  href: "https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/examples/upload_wait_chat.py",
+                  desc: "Full end-to-end flow: upload, wait, chat, print sources.",
+                },
+                {
+                  file: "check_status.py",
+                  href: "https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/examples/check_status.py",
+                  desc: "Poll document status and inspect each ingestion stage.",
+                },
+                {
+                  file: "batch_chat.py",
+                  href: "https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/examples/batch_chat.py",
+                  desc: "Send multiple questions against the same document in sequence.",
+                },
+              ].map(({ file, href, desc }) => (
+                <li key={file} className="flex gap-3">
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 self-start rounded-xl border border-border bg-surface px-2 py-0.5 font-mono text-[0.82rem] text-accent underline underline-offset-4 transition-opacity hover:opacity-80"
+                  >
+                    {file}
+                  </a>
+                  <span>{desc}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
 
-      {/* Footer link */}
-      <p className="mt-16 text-sm text-foreground border-t border-border pt-6">
-        For full SDK details, see the{" "}
-        <a
-          href="https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/README.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-accent underline underline-offset-4 hover:opacity-80 transition-opacity"
-        >
-          SDK README on GitHub
-        </a>
-        .
-      </p>
-    </div>
+        <p className="mt-16 border-t border-border pt-6 text-sm text-foreground/80">
+          For full SDK details, see the{" "}
+          <a
+            href="https://github.com/chatvector-ai/chatvector-ai/blob/main/sdk/python/README.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent underline underline-offset-4 transition-opacity hover:opacity-80"
+          >
+            SDK README on GitHub
+          </a>
+          .
+        </p>
+      </div>
+    </DocLayout>
   );
 }

--- a/frontend-demo/app/sdk/page.tsx
+++ b/frontend-demo/app/sdk/page.tsx
@@ -29,7 +29,9 @@ export default function SdkPage() {
 
           <section>
             <Kicker spacing="lg">installation</Kicker>
-            <p className="mb-3 text-foreground/90">Install directly from the repo:</p>
+            <p className="mb-3 text-foreground/90">
+              Install directly from the repo:
+            </p>
             <pre className="overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
               <code>pip install ./sdk/python</code>
             </pre>
@@ -38,7 +40,8 @@ export default function SdkPage() {
           <section>
             <Kicker spacing="lg">quickstart</Kicker>
             <p className="mb-3 text-foreground/90">
-              Upload a document, wait for ingestion to complete, then ask a question:
+              Upload a document, wait for ingestion to complete, then ask a
+              question:
             </p>
             <pre className="overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
               <code>{`from chatvector import ChatVectorClient
@@ -64,7 +67,8 @@ with ChatVectorClient("http://localhost:8000") as client:
           <section>
             <Kicker spacing="lg">authentication</Kicker>
             <p className="mb-3 text-foreground/90">
-              If your backend is configured with a bearer token, pass it at client initialization:
+              If your backend is configured with a bearer token, pass it at
+              client initialization:
             </p>
             <pre className="overflow-x-auto rounded-xl border border-border bg-surface p-4 font-mono text-[0.82rem]">
               <code>{`client = ChatVectorClient(
@@ -73,14 +77,16 @@ with ChatVectorClient("http://localhost:8000") as client:
 )`}</code>
             </pre>
             <p className="mt-3 text-foreground/90">
-              The token is optional. Omit it if your backend does not require authentication.
+              The token is optional. Omit it if your backend does not require
+              authentication.
             </p>
           </section>
 
           <section>
             <Kicker spacing="lg">error handling</Kicker>
             <p className="mb-4 text-foreground/90">
-              The client raises typed exceptions so you can handle failures cleanly:
+              The client raises typed exceptions so you can handle failures
+              cleanly:
             </p>
             <div className="space-y-3 text-foreground/90">
               {[

--- a/frontend-demo/lib/utils.ts
+++ b/frontend-demo/lib/utils.ts
@@ -1,0 +1,5 @@
+export function cn(
+  ...inputs: (string | undefined | null | false | 0 | 0n)[]
+): string {
+  return inputs.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary

Design consistency pass for Phase 3. Documentation pages had accumulated 
inconsistent header patterns, manual kicker markup, and contrast issues. 
This PR extracts reusable components and applies them uniformly across 
all doc routes and marketing sections.

Standardizes documentation and marketing kickers around a shared Kicker 
component, adds DocLayout and DocPageHeader for doc pages, and aligns 
typography, hierarchy, and link treatment so the demo feels cohesive.

## What changed

### New components (`frontend-demo`)
- **`app/components/Kicker.tsx`** — Shared label styling (`font-mono`, uppercase, `tracking-[2px]`, `text-accent`). `variant="comment"` prepends `// `; `variant="numbered"` is used for architecture section labels (`01 — …`). `spacing` controls bottom margin; optional `className`.
- **`app/components/DocLayout.tsx`** — Full-height shell with centered `main` (`max-w-[720px]`, `px-6`, `py-16 md:py-20`).
- **`app/components/DocPageHeader.tsx`** — Page kicker + `h1` (`text-3xl font-bold tracking-tight`) + optional description (`text-foreground/90`).
- **`lib/utils.ts`** — Small `cn()` helper for class names (no new dependencies).

### Documentation pages
All six doc routes use `DocLayout` + `DocPageHeader` where applicable, with section labels via `Kicker`:
- `getting-started`, `architecture`, `sdk`, `roadmap`, `contributing`, `contributors`

**Architecture** — Fixes heading hierarchy: numbered labels are `Kicker variant="numbered"`; former `h3` section titles are proper **`h2`** (`text-lg font-semibold`).

**Contrast** — Primary body copy on doc pages favors `text-foreground` / `text-foreground/90` / `text-foreground/80` instead of `text-muted` where appropriate (e.g. getting-started lists, roadmap phases).

### Marketing & global kicker usage
- **Home:** `WhatIs`, `Features`, `Developers` use `Kicker spacing="lg"` with comment-style labels (`what is chatvector`, `features`, `for developers`).
- **About:** Three section kickers use the same pattern (`what is chatvector`, `who this is for`, `chatvector vs frameworks`).

### Error / 404 UI
- **`ErrorState`** renders the label through `Kicker` (prop is the text after `// `; default `"error"`). **`not-found`** passes `kicker="404"`.
- Keeps a single place for kicker styling under `app/` (audit: `font-mono` + `uppercase` + `tracking` only on `Kicker.tsx`).

### Polish
- **`Kicker`** uses `text-sm` for readability (aligned with recent home sections).
- **SDK page** — Minor line wrapping in long paragraphs.
- **Contributing** — “Helpful links” list uses `text-muted` with `hover:text-foreground` so links do not compete with the accent kicker; footer link to CONTRIBUTING.md stays accent as the primary CTA.

## Out of scope (unchanged)
- Hero announcement chip, roadmap phase badges inside cards, chat page, and broad token refactors.

## Verification
- `npm run lint` and `npm run build` pass in `frontend-demo`.

## Commits on this branch
1. `feat(frontend-demo): add Kicker, DocLayout, DocPageHeader for doc pages`
2. `refactor(frontend-demo): use Kicker on marketing and error UI`
3. `fix(frontend-demo): About kicker label; align Kicker size and SDK wrap`
4. `style(contributing): soften helpful links vs accent kicker`