### PR TITLE
ci: add frontend and sdk validation to pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,57 @@ jobs:
 
       - name: Build backend image
         run: docker build ./backend -t chatvector-api:ci
+
+  frontend:
+    name: Frontend Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend-demo/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd frontend-demo
+          npm ci
+
+      - name: Lint and Type-check
+        run: |
+          cd frontend-demo
+          npm run lint
+          npm run type-check
+
+      - name: Build
+        run: |
+          cd frontend-demo
+          npm run build
+
+  sdk:
+    name: SDK Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: sdk/python/pyproject.toml
+
+      - name: Install SDK
+        run: |
+          cd sdk/python
+          pip install -e ".[dev]"
+
+      - name: Run SDK tests
+        run: |
+          cd sdk/python
+          pytest tests/ -v --tb=short


### PR DESCRIPTION
This PR expands our CI coverage by adding automated validation for the frontend-demo and the Python SDK.

Previously, only the backend was validated, which left the other components vulnerable to broken builds or lint regressions.

### Changes
- **Frontend Job:**
  - Installs dependencies using \
pm ci\.
  - Runs \
pm run lint\ for code quality.
  - Runs \
pm run type-check\ for TypeScript safety.
  - Performs \
pm run build\ to ensure the demo is production-ready.
- **SDK Job:**
  - Installs the SDK in editable mode with dev dependencies.
  - Runs the full \pytest\ suite in \sdk/python/tests/\.

These jobs are configured to run on every push to \main\ and on all incoming pull requests.

Closes #241