### PR TITLE
feat(backend): Phase 2 audit hardening — validation, queue stats, embedding safety, config docs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 # Application environment
 APP_ENV=development
 # Note: /docs, /redoc, and /openapi.json are disabled when APP_ENV=production
+# GET /queue/stats returns 404 when APP_ENV=production
 
 # Logging
 LOG_LEVEL=INFO
@@ -17,12 +18,12 @@ MAX_UPLOAD_SIZE_MB=10
 # LLM_MODEL=                          # optional; provider picks its default
 # EMBEDDING_PROVIDER=gemini
 # EMBEDDING_MODEL=                    # optional; provider picks its default
-# EMBEDDING_DIM=                      # auto-detected from model; override for unknown models
-                                      # Switching providers requires re-embedding + fresh DB
+# EMBEDDING_DIM=                      # required for models not listed in KNOWN_EMBEDDING_DIMS
+                                      # (see services/providers/base.py). Switching providers
+                                      # requires re-embedding + fresh DB
 
 # Gemini (if LLM_PROVIDER=gemini or EMBEDDING_PROVIDER=gemini)
 GEN_AI_KEY=your_google_ai_studio_api_key_here
-# LLM_HTTP_TIMEOUT_MS=60000           # Gemini HTTP client timeout (milliseconds)
 
 # OpenAI (if LLM_PROVIDER=openai or EMBEDDING_PROVIDER=openai)
 # OPENAI_API_KEY=your_openai_api_key_here
@@ -54,26 +55,38 @@ POSTGRES_DB=postgres
 # SYSTEM_PROMPT_PATH=
 # LLM_TEMPERATURE=0.2
 # LLM_MAX_OUTPUT_TOKENS=1024
+# LLM_HTTP_TIMEOUT_MS=60000           # LLM HTTP client timeout (ms); Gemini uses this explicitly
+# LLM_HEALTH_CHECK_TIMEOUT_SEC=120   # /status LLM probe timeout (seconds)
 
-# ── Queue Backend ─────────────────────────────────────────────────────────
-# QUEUE_BACKEND=memory     # memory (default) or redis
+# ── Queue backend ─────────────────────────────────────────────────────────
+# QUEUE_BACKEND=memory                # memory (default) or redis
 # REDIS_URL=redis://localhost:6379/0
 
 # ── Background ingestion queue ────────────────────────────────────────────
-# QUEUE_RETRY_BASE_DELAY=2.0  # base seconds for queue job retry backoff
+# QUEUE_WORKER_COUNT=3                # clamped to 1–5
+# QUEUE_MAX_SIZE=100                  # max jobs waiting; over capacity → 503 on upload
+# QUEUE_EMBEDDING_RPS=2.0             # token-bucket rate for embedding calls (per process)
+# QUEUE_JOB_MAX_RETRIES=3
+# QUEUE_RETRY_BASE_DELAY=2.0          # base seconds for exponential backoff between retries
 
-# Status health checks
-HEALTH_CHECK_CACHE_TTL_SECONDS=60
-# LLM health check probe timeout (seconds). Default 120 accommodates Ollama
-# cold start on modest hardware; lower for managed APIs if you want faster
-# failure detection.
-# LLM_HEALTH_CHECK_TIMEOUT_SEC=120
+# ── Retrieval & chat limits ────────────────────────────────────────────────
+# RETRIEVAL_MAX_CONCURRENCY=8         # max concurrent vector searches (chat retrieval)
+# SQLALCHEMY_RETRIEVAL_CONCURRENCY=8  # max concurrent DB sessions for pgvector search
+# CHAT_BATCH_MAX_ITEMS=20             # max queries per POST /chat/batch
+# CHAT_MAX_DOC_IDS_PER_QUERY=10       # max document IDs per batch item
 
-# ── SQLAlchemy / PostgreSQL ───────────────────────────────────────────────
-# SQLALCHEMY_STATEMENT_TIMEOUT_SEC=30
+# ── SQLAlchemy / PostgreSQL (development / local Postgres) ───────────────
+# SQLALCHEMY_POOL_SIZE=5
+# SQLALCHEMY_MAX_OVERFLOW=10
+# SQLALCHEMY_POOL_TIMEOUT_SEC=30
+# SQLALCHEMY_STATEMENT_TIMEOUT_SEC=30 # asyncpg command_timeout (seconds)
 
-# ── Supabase ──────────────────────────────────────────────────────────────
+# ── Supabase (production client) ─────────────────────────────────────────
 # SUPABASE_HTTP_TIMEOUT_SEC=30
+# SUPABASE_IO_CONCURRENCY=16          # thread-pool + asyncio semaphore for SDK calls
+
+# ── Health checks ─────────────────────────────────────────────────────────
+# HEALTH_CHECK_CACHE_TTL_SECONDS=60   # 0 = always re-run checks
 
 # ── CORS ──────────────────────────────────────────────────────────────────
 # CORS_ORIGINS=http://localhost:3000

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,8 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI,Request
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi.errors import RateLimitExceeded
@@ -73,6 +74,27 @@ app = FastAPI(
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+
+
+async def request_validation_exception_handler(
+    _request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=422,
+        content={
+            "detail": {
+                "code": "validation_error",
+                "message": "Request validation failed",
+                "fields": [
+                    {"loc": list(err.get("loc", ())), "msg": err.get("msg", "")}
+                    for err in exc.errors()
+                ],
+            }
+        },
+    )
+
+
+app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
 
 
 @app.exception_handler(Exception)

--- a/backend/routes/queue.py
+++ b/backend/routes/queue.py
@@ -1,6 +1,6 @@
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 
 from core.config import config
 from middleware.rate_limit import limiter
@@ -10,14 +10,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # =============================================================================
-# SECURITY / OPS WARNING — READ BEFORE DEPLOYMENT
+# SECURITY / OPS — READ BEFORE DEPLOYMENT
 # -----------------------------------------------------------------------------
-# GET /queue/stats is UNAUTHENTICATED and returns internal operational metrics
-# (queue depth, worker task count, dead-letter metadata). This is intended for
-# trusted local or private-network debugging only. Before any public, shared, or
-# multi-tenant deployment, this route MUST be gated (e.g. auth, admin-only
-# network policy, reverse-proxy allowlist, or feature flag). Do not expose it to
-# the open internet without explicit review.
+# GET /queue/stats returns internal operational metrics (queue depth, worker
+# count, DLQ metadata). It is disabled when APP_ENV=production (404). In
+# non-production environments it remains available for local debugging; gate
+# further (auth, allowlist) if you run a shared staging environment.
 # =============================================================================
 
 
@@ -29,6 +27,8 @@ def get_queue_stats(request: Request):
 
     DLQ entries include only lightweight metadata; file bytes are never exposed.
     """
+    if config.APP_ENV.lower() == "production":
+        raise HTTPException(status_code=404, detail="Not found")
     dlq_entries = [
         {
             "doc_id": entry.doc_id,

--- a/backend/services/providers/base.py
+++ b/backend/services/providers/base.py
@@ -103,7 +103,15 @@ class EmbeddingProvider(ABC):
                 dim = KNOWN_EMBEDDING_DIMS.get(model.rsplit("/", 1)[1])
                 if dim:
                     return dim
-        return 3072  # backward-compatible Gemini default
+            raise ValueError(
+                f"Unknown embedding model {model!r}. "
+                f"Set EMBEDDING_DIM in the environment or add the model to "
+                f"KNOWN_EMBEDDING_DIMS in services/providers/base.py."
+            )
+        raise ValueError(
+            "Cannot resolve embedding dimension: provider has no _model set. "
+            "Set EMBEDDING_DIM in the environment or ensure the provider sets _model."
+        )
 
 
 class LLMProvider(ABC):

--- a/backend/tests/test_input_validation.py
+++ b/backend/tests/test_input_validation.py
@@ -4,11 +4,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
+from main import request_validation_exception_handler
 from middleware.rate_limit import limiter
 from routes.chat import router as chat_router
 
@@ -31,6 +33,7 @@ async def _rate_limit_exceeded_handler(
 def _chat_validation_app() -> FastAPI:
     app = FastAPI()
     app.state.limiter = limiter
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.add_middleware(SlowAPIMiddleware)
     app.include_router(chat_router)
@@ -102,3 +105,19 @@ def test_chat_doc_id_over_max_length_returns_422(client):
     ):
         resp = client.post("/chat", json=payload)
     assert resp.status_code == 422
+
+
+def test_chat_validation_error_envelope(client):
+    """Missing / invalid body fields use the standard detail.code / detail.fields shape."""
+    with patch(
+        "routes.chat.answer_question_for_document",
+        new=AsyncMock(return_value={"answer": "ok", "chunks": 0}),
+    ):
+        resp = client.post("/chat", json={"doc_ids": ["only-wrong-field"]})
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data["detail"]["code"] == "validation_error"
+    assert data["detail"]["message"] == "Request validation failed"
+    assert "fields" in data["detail"]
+    assert isinstance(data["detail"]["fields"], list)
+    assert all("loc" in f and "msg" in f for f in data["detail"]["fields"])

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -401,3 +401,23 @@ class TestOllamaGenerateParsing:
         )
 
         assert result == "No response."
+
+
+class TestEmbeddingDimResolution:
+    """embedding_dim must not silently default for unknown models."""
+
+    def test_unknown_model_raises(self):
+        from services.providers.gemini import GeminiEmbeddingProvider
+
+        provider = GeminiEmbeddingProvider(
+            api_key="test-key", model="totally-unknown-model-xyz"
+        )
+        with pytest.raises(ValueError, match="Unknown embedding model"):
+            _ = provider.embedding_dim
+
+    def test_provider_prefixed_name_resolves(self):
+        """Slash-suffix lookup must work without importing optional OpenAI deps."""
+        from services.providers.ollama import OllamaEmbeddingProvider
+
+        provider = OllamaEmbeddingProvider(model="registry/nomic-embed-text")
+        assert provider.embedding_dim == 768

--- a/backend/tests/test_queue_route.py
+++ b/backend/tests/test_queue_route.py
@@ -1,0 +1,51 @@
+"""HTTP behavior for the queue stats route (environment gating)."""
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+
+from core.config import config
+from middleware.rate_limit import limiter
+from routes.queue import router as queue_router
+
+
+async def _rate_limit_exceeded_handler(
+    _request: Request, _exc: RateLimitExceeded
+) -> JSONResponse:
+    return JSONResponse(status_code=429, content={"detail": "rate limited"})
+
+
+def _queue_app() -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)
+    app.include_router(queue_router)
+    return app
+
+
+def test_queue_stats_returns_404_in_production(monkeypatch):
+    monkeypatch.setattr(config, "APP_ENV", "production")
+    limiter.reset()
+    try:
+        with TestClient(_queue_app()) as client:
+            resp = client.get("/queue/stats")
+        assert resp.status_code == 404
+    finally:
+        limiter.reset()
+
+
+def test_queue_stats_returns_200_in_non_production(monkeypatch):
+    monkeypatch.setattr(config, "APP_ENV", "development")
+    limiter.reset()
+    try:
+        with TestClient(_queue_app()) as client:
+            resp = client.get("/queue/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "queue_size" in data
+        assert "dlq" in data
+    finally:
+        limiter.reset()


### PR DESCRIPTION
## Context

This PR implements a first batch of **Phase 3 / production-readiness** changes that came out of a **comprehensive backend code quality audit** before wrapping Phase 2. The audit covered error handling, logging, types, async patterns, tests, configuration drift, security, the in-memory queue, and provider abstractions. Several follow-ups were classified as P1; this PR addresses four of them that are small, self-contained, and high leverage for real deployments.

**Scope:** general **API and configuration hardening** — not a feature release. Other audit items (e.g. OpenAI/ollama LLM timeout parity, Supabase delete atomicity, app logging to console) are intentionally out of scope here.

---

## Summary of changes

| Area | Change |
|------|--------|
| **API consistency** | `422` validation errors use the same structured `detail` shape as the rest of the app (`code`, `message`, `fields`). |
| **Security / ops** | `GET /queue/stats` is not exposed in production (returns `404`), reducing risk of leaking queue/DLQ metadata on the public internet. |
| **Data safety** | Unknown embedding models no longer default to dimension `3072`; operators must set `EMBEDDING_DIM` or extend `KNOWN_EMBEDDING_DIMS`, avoiding silent vector/DB mismatch. |
| **Documentation** | `backend/.env.example` documents major tunables (queue, retrieval, DB pools, health) aligned with `core/config.py`. |
| **Tests** | Coverage for the new validation envelope, queue gating, and embedding-dimension resolution. |

---

## File-by-file rationale

### `backend/main.py`
- **What:** Register a `RequestValidationError` handler that returns HTTP `422` with:
  - `detail.code` = `validation_error`
  - `detail.message` = `Request validation failed`
  - `detail.fields` = list of `{ loc, msg }` derived from Pydantic/FastAPI validation errors
- **Why:** FastAPI’s default `422` body is a different shape than our hand-typed errors (e.g. `detail: { code, message }` elsewhere). Clients and the demo frontend can rely on one pattern for *all* errors. Also fixes use of `Request` in the global handler by importing it explicitly from `fastapi`.

### `backend/routes/queue.py`
- **What:** If `APP_ENV` is `production`, raise `HTTPException(404, \"Not found\")` before returning queue depth, worker count, or DLQ entries.
- **Why:** The audit flagged `/queue/stats` as unauthenticated operational surface. Gating in production (simplest option) blocks accidental exposure when the API is open to the internet; dev/staging can still use the endpoint for debugging.

### `backend/services/providers/base.py`
- **What:** `EmbeddingProvider.embedding_dim` no longer falls back to `3072` for unknown `self._model`. It raises `ValueError` with guidance to set `EMBEDDING_DIM` or add the model to `KNOWN_EMBEDDING_DIMS`. Missing `_model` also raises.
- **Why:** A silent default can write vectors of the wrong width relative to the DB or mix incompatible spaces without failing fast at config time.

### `backend/.env.example`
- **What:** Expanded comments and optional variables for queue sizing, `QUEUE_BACKEND` / `REDIS_URL`, retrieval and chat limits, SQLAlchemy pool and statement timeouts, Supabase I/O concurrency, health-check TTL, and LLM timeout-related vars — names match `core/config.py`.
- **Why:** The audit found sparse `.env.example` vs. `Settings`, which slows onboarding and encourages guessing env names.

### `backend/tests/test_input_validation.py`
- **What:** Register the same validation handler on the test app; add `test_chat_validation_error_envelope` for a bad body (e.g. wrong fields) and assert the new `detail` shape.
- **Why:** Locks in the contract so future FastAPI/Pydantic upgrades do not silently revert response shape.

### `backend/tests/test_queue_route.py` (new)
- **What:** Assert `GET /queue/stats` returns `404` when `config.APP_ENV` is production and `200` with expected keys when non-production. Uses the same rate-limit wiring as other route tests.
- **Why:** Prevents production gating from regressing.

### `backend/tests/test_providers.py`
- **What:** `TestEmbeddingDimResolution` — unknown Gemini model name raises; Ollama `registry/nomic-embed-text` resolves via slash-suffix without requiring the optional `openai` package.
- **Why:** Encodes the fail-fast and prefix-resolution behavior without optional deps.

---

## How to verify locally

- **Validation:** `POST /chat` with an invalid body → `422` and `detail.code == \"validation_error\"`.
- **Queue stats:** With `APP_ENV=production` → `GET /queue/stats` → `404`.
- **Tests:** `make tests` (or `docker compose run --rm tests` from repo root).

---

## Related (not in this PR)

- Provider HTTP timeout parity (e.g. OpenAI LLM client vs. Gemini `LLM_HTTP_TIMEOUT_MS`)
- Shipping application logs to stdout in dev
- Broader chat error contract (soft LLM strings vs. structured errors)

