### PR TITLE
color code for sdk IDE-style and making hero cosistence

### DIFF
--- a/frontend-demo/app/components/home/Developers.tsx
+++ b/frontend-demo/app/components/home/Developers.tsx
@@ -41,7 +41,7 @@ export default function Developers() {
         { c: SYNTAX.plain, t: "(doc.document_id)" },
       ],
     },
-    { parts: [] },
+    { parts: [{ c: SYNTAX.plain, t: " " }] },
     { parts: [{ c: SYNTAX.cm, t: "# Ask questions against the document" }] },
     {
       parts: [
@@ -59,7 +59,7 @@ export default function Developers() {
     },
     { parts: [{ c: SYNTAX.plain, t: "  doc.document_id" }] },
     { parts: [{ c: SYNTAX.plain, t: ")" }] },
-    { parts: [] },
+    { parts: [{ c: SYNTAX.plain, t: " " }] },
     {
       parts: [{ c: SYNTAX.cm, t: "# Full response with source citations" }],
     },

--- a/frontend-demo/app/components/home/Hero.tsx
+++ b/frontend-demo/app/components/home/Hero.tsx
@@ -1,67 +1,83 @@
 import Link from "next/link";
 
-import { GITHUB_REPO } from "../../lib/constants";
+import { GITHUB_REPO, SYNTAX } from "../../lib/constants";
 import CodeBlock from "../CodeBlock";
 
 function HeroCodeBlock() {
-  const lines = [
-    { type: "keyword", text: "from " },
-    { type: "default", text: "chatvector " },
-    { type: "keyword", text: "import " },
-    { type: "function", text: "ChatVectorClient" },
-    { type: "br" },
-    { type: "br" },
-    { type: "comment", text: "# Point the client at your running instance" },
-    { type: "br" },
-    { type: "default", text: "cv = " },
-    { type: "function", text: "ChatVectorClient" },
-    { type: "default", text: "(" },
-    { type: "string", text: '"http://localhost:8000"' },
-    { type: "default", text: ")" },
-    { type: "br" },
-    { type: "br" },
-    { type: "comment", text: "# Upload a document" },
-    { type: "br" },
-    { type: "default", text: "doc = cv." },
-    { type: "function", text: "upload_document" },
-    { type: "default", text: "(" },
-    { type: "string", text: '"contract.pdf"' },
-    { type: "default", text: ")" },
-    { type: "br" },
-    { type: "default", text: "cv." },
-    { type: "function", text: "wait_for_ready" },
-    { type: "default", text: "(doc.document_id)" },
-    { type: "br" },
-    { type: "br" },
-    { type: "comment", text: "# Get a grounded, cited answer" },
-    { type: "br" },
-    { type: "default", text: "answer = cv." },
-    { type: "function", text: "chat" },
-    { type: "default", text: "(" },
-    { type: "string", text: '"What are the payment terms?"' },
-    { type: "default", text: ", doc.document_id)" },
-    { type: "br" },
-    { type: "default", text: "print(answer.answer)  " },
-    { type: "comment", text: "# Cited, accurate" },
-  ];
-
+ const codeLines = [
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "from " },
+      { c: SYNTAX.plain, t: "chatvector " },
+      { c: SYNTAX.kw, t: "import " },
+      { c: SYNTAX.fn, t: "ChatVectorClient" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.cm, t: "# Point the client at your running instance" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "cv = " },
+      { c: SYNTAX.fn, t: "ChatVectorClient" },
+      { c: SYNTAX.plain, t: "(" },
+      { c: SYNTAX.str, t: '"http://localhost:8000"' },
+      { c: SYNTAX.plain, t: ")" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.cm, t: "# Upload a document" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "doc = cv." },
+      { c: SYNTAX.fn, t: "upload_document" },
+      { c: SYNTAX.plain, t: "(" },
+      { c: SYNTAX.str, t: '"contract.pdf"' },
+      { c: SYNTAX.plain, t: ")" },
+    ],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "cv." },
+      { c: SYNTAX.fn, t: "wait_for_ready" },
+      { c: SYNTAX.plain, t: "(doc.document_id)" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.cm, t: "# Get a grounded, cited answer" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "answer = cv." },
+      { c: SYNTAX.fn, t: "chat" },
+      { c: SYNTAX.plain, t: "(" },
+      { c: SYNTAX.str, t: '"What are the payment terms?"' },
+      { c: SYNTAX.plain, t: ", doc.document_id)" },
+    ],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "print(answer.answer)  " },
+      { c: SYNTAX.cm, t: "# Cited, accurate" },
+    ],
+  },
+];
   return (
     <div className="relative z-[1] mt-12 w-full max-w-[700px]">
       <CodeBlock language="python" filename="quickstart.py">
-        {lines.map((t, i) =>
-          t.type === "br" ? (
-            <br key={i} />
-          ) : (
-            <span
-              key={i}
-              style={{
-                color: `var(--syntax-${t.type})`,
-              }}
-            >
-              {t.text}
-            </span>
-          ),
-        )}
+        {codeLines.map((line, i) => (
+              <div key={i}>
+                {line.parts.map((p, j) => (
+                  <span key={j} style={{ color: p.c }}>
+                    {p.t}
+                  </span>
+                ))}
+              </div>
+            ))}
       </CodeBlock>
     </div>
   );

--- a/frontend-demo/app/sdk/page.tsx
+++ b/frontend-demo/app/sdk/page.tsx
@@ -1,10 +1,166 @@
 import { DocLayout } from "@/app/components/DocLayout";
 import { DocPageHeader } from "@/app/components/DocPageHeader";
 import { Kicker } from "@/app/components/Kicker";
-
 import CodeBlock from "../components/CodeBlock";
+import { SYNTAX } from "../lib/constants";
 
 export default function SdkPage() {
+  const upload_chat_codeLines = [
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "from " },
+      { c: SYNTAX.plain, t: "chatvector " },
+      { c: SYNTAX.kw, t: "import " },
+      { c: SYNTAX.fn, t: "ChatVectorClient" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "with " },
+      { c: SYNTAX.fn, t: "ChatVectorClient" },
+      { c: SYNTAX.plain, t: "(" },
+      { c: SYNTAX.str, t: '"http://localhost:8000"' },
+      { c: SYNTAX.plain, t: ")" },
+      { c: SYNTAX.kw, t: " as " },
+      { c: SYNTAX.plain, t: "client:" },
+    ],
+  },
+  {
+    parts: [{ c: SYNTAX.cm, t: "    # Upload a document" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "    doc = client." },
+      { c: SYNTAX.fn, t: "upload_document" },
+      { c: SYNTAX.plain, t: "(" },
+      { c: SYNTAX.str, t: '"report.pdf"' },
+      { c: SYNTAX.plain, t: ")" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.cm, t: "    # Wait until the document is ready to query" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "    client." },
+      { c: SYNTAX.fn, t: "wait_for_ready" },
+      { c: SYNTAX.plain, t: "(doc.document_id, timeout=90)" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.cm, t: "    # Ask a question" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "    answer = client." },
+      { c: SYNTAX.fn, t: "chat" },
+      { c: SYNTAX.plain, t: "(" },
+      { c: SYNTAX.str, t: '"What are the key findings?"' },
+      { c: SYNTAX.plain, t: ", doc.document_id)" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.plain, t: "    print(answer.answer)" }],
+  },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  {
+    parts: [{ c: SYNTAX.cm, t: "    # Print cited sources" }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "    for " },
+      { c: SYNTAX.plain, t: "source " },
+      { c: SYNTAX.kw, t: "in " },
+      { c: SYNTAX.plain, t: "answer.sources:" },
+    ],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "        print(source.file_name, source.page_number)" },
+    ],
+  },
+];
+  const error_handling_codeLines = [
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "from " },
+      { c: SYNTAX.plain, t: "chatvector.exceptions " },
+      { c: SYNTAX.kw, t: "import (" },
+    ],
+  },
+  { parts: [{ c: SYNTAX.fn, t: "    ChatVectorAPIError," }] },
+  { parts: [{ c: SYNTAX.fn, t: "    ChatVectorAuthError," }] },
+  { parts: [{ c: SYNTAX.fn, t: "    ChatVectorRateLimitError," }] },
+  { parts: [{ c: SYNTAX.fn, t: "    ChatVectorTimeoutError," }] },
+  { parts: [{ c: SYNTAX.plain, t: ")" }] },
+  { parts: [{ c: SYNTAX.plain, t: " " }] },
+  { parts: [{ c: SYNTAX.kw, t: "try:" }] },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "    doc = client." },
+      { c: SYNTAX.fn, t: "upload_document" },
+      { c: SYNTAX.plain, t: '("report.pdf")' },
+    ],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "    client." },
+      { c: SYNTAX.fn, t: "wait_for_ready" },
+      { c: SYNTAX.plain, t: "(doc.document_id, timeout=60)" },
+    ],
+  },
+  {
+    parts: [
+      { c: SYNTAX.plain, t: "    answer = client." },
+      { c: SYNTAX.fn, t: "chat" },
+      { c: SYNTAX.plain, t: '("Summarise the document.", doc.document_id)' },
+    ],
+  },
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "except " },
+      { c: SYNTAX.fn, t: "ChatVectorAuthError" },
+      { c: SYNTAX.plain, t: ":" },
+    ],
+  },
+  {
+    parts: [{ c: SYNTAX.plain, t: '    print("Authentication failed. Check your api_key.")' }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "except " },
+      { c: SYNTAX.fn, t: "ChatVectorRateLimitError" },
+      { c: SYNTAX.plain, t: ":" },
+    ],
+  },
+  {
+    parts: [{ c: SYNTAX.plain, t: '    print("Rate limit hit. Wait and retry.")' }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "except " },
+      { c: SYNTAX.fn, t: "ChatVectorTimeoutError" },
+      { c: SYNTAX.plain, t: ":" },
+    ],
+  },
+  {
+    parts: [{ c: SYNTAX.plain, t: '    print("Document took too long to process.")' }],
+  },
+  {
+    parts: [
+      { c: SYNTAX.kw, t: "except " },
+      { c: SYNTAX.fn, t: "ChatVectorAPIError" },
+      { c: SYNTAX.plain, t: " as e:" },
+    ],
+  },
+  {
+    parts: [{ c: SYNTAX.plain, t: '    print("SDK error:", e)' }],
+  },
+];
   return (
     <DocLayout>
       <div className="text-[1rem] leading-[1.8] text-foreground">
@@ -44,23 +200,15 @@ export default function SdkPage() {
               question:
             </p>
             <CodeBlock language="python" filename="upload_and_chat.py">
-              <code>{`from chatvector import ChatVectorClient
-
-with ChatVectorClient("http://localhost:8000") as client:
-    # Upload a document
-    doc = client.upload_document("report.pdf")
-
-    # Wait until the document is ready to query
-    client.wait_for_ready(doc.document_id, timeout=90)
-
-    # Ask a question
-    answer = client.chat("What are the key findings?", doc.document_id)
-
-    print(answer.answer)
-
-    # Print cited sources
-    for source in answer.sources:
-        print(source.file_name, source.page_number)`}</code>
+             {upload_chat_codeLines.map((line, i) => (
+              <div key={i}>
+                {line.parts.map((p, j) => (
+                  <span key={j} style={{ color: p.c }}>
+                    {p.t}
+                  </span>
+                ))}
+              </div>
+            ))}
             </CodeBlock>
           </section>
 
@@ -118,25 +266,15 @@ with ChatVectorClient("http://localhost:8000") as client:
             </div>
             <div className="mt-5">
               <CodeBlock language="python" filename="error_handling.py">
-                <code>{`from chatvector.exceptions import (
-    ChatVectorAPIError,
-    ChatVectorAuthError,
-    ChatVectorRateLimitError,
-    ChatVectorTimeoutError,
-)
-
-try:
-    doc = client.upload_document("report.pdf")
-    client.wait_for_ready(doc.document_id, timeout=60)
-    answer = client.chat("Summarise the document.", doc.document_id)
-except ChatVectorAuthError:
-    print("Authentication failed. Check your api_key.")
-except ChatVectorRateLimitError:
-    print("Rate limit hit. Wait and retry.")
-except ChatVectorTimeoutError:
-    print("Document took too long to process.")
-except ChatVectorAPIError as e:
-    print("SDK error:", e)`}</code>
+                {error_handling_codeLines.map((line, i) => (
+              <div key={i}>
+                {line.parts.map((p, j) => (
+                  <span key={j} style={{ color: p.c }}>
+                    {p.t}
+                  </span>
+                ))}
+              </div>
+            ))}
               </CodeBlock>
             </div>
           </section>


### PR DESCRIPTION
## Summary
Refactored the SDK page to use IDE-style syntax highlighting, consistent 
with the existing pattern in `developers.tsx`.

## Changes
- **hero.tsx** — refactored to use the same component architecture as `developers.tsx`
- **developers.tsx** — added new line (`{ parts: [] }`) support for blank line rendering
- **sdk.tsx** — added `upload_chat_codeLines` and `error_handling_codeLines` 
  with full syntax highlighting using `SYNTAX` tokens (keyword, function, string, comment)

## Approach
Used `developers.tsx` as the base architecture and extended it across 
`hero.tsx` and `sdk.tsx` for a consistent IDE-style code display.## Screenshots
hero.tsx:
<img width="702" height="374" alt="Screenshot From 2026-04-25 21-41-32" src="https://github.com/user-attachments/assets/97c2c12a-0261-4133-ae47-6121bcd83476" />
developers.tsx:
<img width="526" height="373" alt="Screenshot From 2026-04-25 21-42-00" src="https://github.com/user-attachments/assets/2c037e3a-66c4-412f-8b04-5d72feb7b975" />
sdk.tsx:
a)upload_chat_codeLines:
<img width="676" height="485" alt="Screenshot From 2026-04-25 21-42-30" src="https://github.com/user-attachments/assets/2eb9f95e-b725-4d25-b9d1-702da1fdc78d" />
b)error_handling_codeLines
<img width="686" height="523" alt="Screenshot From 2026-04-25 21-42-46" src="https://github.com/user-attachments/assets/8110be9c-43f4-4307-b127-5addae8959e7" />

pr #252 