### PR TITLE
fix(backend): final Phase 3 hardening (preflight polish + pre-auth wiring)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,10 +45,15 @@ POSTGRES_DB=postgres
 # CHUNKING_STRATEGY=fixed
 # CHUNK_SIZE=1000
 # CHUNK_OVERLAP=200
+# If using semantic chunking, ensure NLTK tokenizer is available:
+# python -m nltk.downloader punkt
 
 # ── Query Transformations ─────────────────────────────────────────────────
 # QUERY_TRANSFORMATION_ENABLED=false
 # QUERY_TRANSFORMATION_STRATEGY=rewrite  # rewrite | expand | stepback
+
+# ── Context window ────────────────────────────────────────────────────────
+# MAX_CONTEXT_CHARS=32000             # max chars of retrieved context sent to LLM; drops whole chunks
 
 # ── LLM / Prompt ──────────────────────────────────────────────────────────
 # Path to system prompt file (default: backend/prompts/default_system.txt)

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,0 +1,10 @@
+from fastapi import Depends  # noqa: F401  — kept for Phase 3 wiring
+
+
+def require_auth() -> dict:
+    """
+    Phase 3 placeholder.
+
+    Will return tenant context once authentication is implemented.
+    """
+    return {"tenant_id": None}

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -5,30 +5,11 @@ import uuid
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
 
-from core.config import config, get_embedding_dim
+from core.config import get_embedding_dim
 
 Base = declarative_base()
-
-# async engine
-_db_url = config.DATABASE_URL
-if _db_url is None:
-    raise RuntimeError(
-        "DATABASE_URL is not set. Set it in backend/.env or the environment."
-    )
-DATABASE_URL = _db_url
-async_engine = create_async_engine(
-    DATABASE_URL,
-    echo=True,
-)
-
-async_session = async_sessionmaker(
-    async_engine,
-    expire_on_commit=False,
-    class_=AsyncSession,
-)
 
 
 class Document(Base):

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -154,7 +154,11 @@ class SQLAlchemyService(DatabaseService):
         async with self.async_session() as session:
             document = await session.get(Document, doc_id)
             if not document:
-                raise ValueError(f"Document {doc_id} not found")
+                logger.warning(
+                    "[PostgreSQL] update_document_status: document %s not found, skipping",
+                    doc_id,
+                )
+                return
 
             document.status = status
             if error is not None:

--- a/backend/logging_config/logging_config.py
+++ b/backend/logging_config/logging_config.py
@@ -101,9 +101,11 @@ def setup_logging(
     )
     access_file_handler.setFormatter(uvicorn_formatter)
 
+    log_level = getattr(logging, config.LOG_LEVEL, logging.INFO)
+
     # -------- ROOT LOGGER (APP LOGS) --------
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(log_level)
     root_logger.handlers.clear()
     root_logger.addHandler(file_handler)
 
@@ -113,5 +115,5 @@ def setup_logging(
         logger.handlers.clear()
         logger.addHandler(console_handler)
         logger.addHandler(access_file_handler)
-        logger.setLevel(logging.INFO)
+        logger.setLevel(log_level)
         logger.propagate = False

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -1,4 +1,5 @@
 import logging
+from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -17,7 +18,7 @@ router = APIRouter()
 
 class ChatBatchItem(BaseModel):
     question: str = Field(..., min_length=1, max_length=2000)
-    doc_ids: list[str] = Field(..., min_length=1)
+    doc_ids: list[UUID] = Field(..., min_length=1)
     match_count: int = Field(default=5, ge=1, le=20)
 
 
@@ -27,7 +28,7 @@ class ChatBatchRequest(BaseModel):
 
 class ChatRequest(BaseModel):
     question: str = Field(..., min_length=1, max_length=2000)
-    doc_id: str = Field(..., min_length=1, max_length=100)
+    doc_id: UUID
     match_count: int = Field(default=5, ge=1, le=20)
 
 
@@ -37,7 +38,7 @@ async def chat(request: Request, payload: ChatRequest):
     logger.info(f"Chat request received for document {payload.doc_id}")
     return await answer_question_for_document(
         question=payload.question,
-        doc_id=payload.doc_id,
+        doc_id=str(payload.doc_id),
         match_count=payload.match_count,
     )
 
@@ -49,7 +50,7 @@ async def chat_batch(request: Request, payload: ChatBatchRequest):
 
     try:
         results = await answer_questions_for_documents_batch(
-            [query.model_dump() for query in payload.queries]
+            [query.model_dump(mode="json") for query in payload.queries]
         )
     except ValueError as e:
         raise HTTPException(

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -1,8 +1,9 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from core.auth import require_auth
 from core.config import config
 from middleware.rate_limit import limiter
 from pydantic import BaseModel, Field
@@ -34,7 +35,7 @@ class ChatRequest(BaseModel):
 
 @router.post("/chat")
 @limiter.limit(config.RATE_LIMIT_CHAT)
-async def chat(request: Request, payload: ChatRequest):
+async def chat(request: Request, payload: ChatRequest, auth: dict = Depends(require_auth)):
     logger.info(f"Chat request received for document {payload.doc_id}")
     return await answer_question_for_document(
         question=payload.question,
@@ -45,7 +46,7 @@ async def chat(request: Request, payload: ChatRequest):
 
 @router.post("/chat/batch")
 @limiter.limit(config.RATE_LIMIT_CHAT_BATCH)
-async def chat_batch(request: Request, payload: ChatBatchRequest):
+async def chat_batch(request: Request, payload: ChatBatchRequest, auth: dict = Depends(require_auth)):
     logger.info(f"Batch chat request received with {len(payload.queries)} queries")
 
     try:

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -1,4 +1,5 @@
 import logging
+from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, Response
 
@@ -15,8 +16,8 @@ router = APIRouter()
 
 @router.get("/documents/{document_id}/status")
 @limiter.limit(config.RATE_LIMIT_DOCUMENT_STATUS)
-async def get_document_status(request: Request, document_id: str):
-    status_payload = await db.get_document_status(document_id)
+async def get_document_status(request: Request, document_id: UUID):
+    status_payload = await db.get_document_status(str(document_id))
     if not status_payload:
         raise HTTPException(
             status_code=404,
@@ -28,7 +29,7 @@ async def get_document_status(request: Request, document_id: str):
         )
 
     response: dict = {
-        "document_id": status_payload["document_id"],
+        "document_id": str(document_id),
         "status": status_payload.get("status"),
         "chunks": status_payload.get("chunks"),
         "created_at": status_payload.get("created_at"),
@@ -39,7 +40,7 @@ async def get_document_status(request: Request, document_id: str):
         response["error"] = status_payload["error"]
 
     if status_payload.get("status") == "queued":
-        queue_pos = ingestion_queue.queue_position(document_id)
+        queue_pos = ingestion_queue.queue_position(str(document_id))
         if queue_pos is not None:
             response["queue_position"] = queue_pos
 
@@ -48,8 +49,8 @@ async def get_document_status(request: Request, document_id: str):
 
 @router.delete("/documents/{document_id}", status_code=204)
 @limiter.limit(config.RATE_LIMIT_DOCUMENT_DELETE)
-async def delete_document(request: Request, document_id: str):
-    status_payload = await db.get_document_status(document_id)
+async def delete_document(request: Request, document_id: UUID):
+    status_payload = await db.get_document_status(str(document_id))
     if not status_payload:
         raise HTTPException(
             status_code=404,
@@ -69,19 +70,19 @@ async def delete_document(request: Request, document_id: str):
             detail={
                 "code": "document_processing",
                 "message": f"Document cannot be deleted while in '{status}' state.",
-                "document_id": document_id,
+                "document_id": str(document_id),
             },
         )
-        
-    if ingestion_queue.queue_position(document_id) is not None:
+
+    if ingestion_queue.queue_position(str(document_id)) is not None:
         raise HTTPException(
             status_code=409,
             detail={
                 "code": "document_queued",
                 "message": "Document cannot be deleted while in the queue.",
-                "document_id": document_id,
+                "document_id": str(document_id),
             },
         )
 
-    await db.delete_document(document_id)
+    await db.delete_document(str(document_id))
     return Response(status_code=204)

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -1,8 +1,9 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
+from core.auth import require_auth
 from core.config import config
 from middleware.rate_limit import limiter
 
@@ -16,7 +17,7 @@ router = APIRouter()
 
 @router.get("/documents/{document_id}/status")
 @limiter.limit(config.RATE_LIMIT_DOCUMENT_STATUS)
-async def get_document_status(request: Request, document_id: UUID):
+async def get_document_status(request: Request, document_id: UUID, auth: dict = Depends(require_auth)):
     status_payload = await db.get_document_status(str(document_id))
     if not status_payload:
         raise HTTPException(
@@ -49,7 +50,7 @@ async def get_document_status(request: Request, document_id: UUID):
 
 @router.delete("/documents/{document_id}", status_code=204)
 @limiter.limit(config.RATE_LIMIT_DOCUMENT_DELETE)
-async def delete_document(request: Request, document_id: UUID):
+async def delete_document(request: Request, document_id: UUID, auth: dict = Depends(require_auth)):
     status_payload = await db.get_document_status(str(document_id))
     if not status_payload:
         raise HTTPException(

--- a/backend/routes/queue.py
+++ b/backend/routes/queue.py
@@ -1,7 +1,8 @@
 import logging
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from core.auth import require_auth
 from core.config import config
 from middleware.rate_limit import limiter
 from services.queue_service import ingestion_queue
@@ -21,7 +22,7 @@ router = APIRouter()
 
 @router.get("/queue/stats")
 @limiter.limit(config.RATE_LIMIT_QUEUE_STATS)
-def get_queue_stats(request: Request):
+def get_queue_stats(request: Request, auth: dict = Depends(require_auth)):
     """
     Return live ingestion queue statistics and dead-letter queue entries.
 

--- a/backend/routes/status.py
+++ b/backend/routes/status.py
@@ -9,12 +9,13 @@ from pathlib import Path
 from typing import Any
 
 import psutil
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import SQLAlchemyError
 
 import db
+from core.auth import require_auth
 from core.clients import redis_client
 from core.config import config
 from middleware.rate_limit import limiter
@@ -423,7 +424,7 @@ def _status_fallback_health_dict(exc: BaseException, label: str) -> dict:
 
 @router.get("/status")
 @limiter.limit(config.RATE_LIMIT_STATUS)
-async def status(request: Request):
+async def status(request: Request, auth: dict = Depends(require_auth)):
     start = getattr(request.app.state, "start_time", time.time())
     db_result, embedding_result, llm_result = await asyncio.gather(
         _database_connected_and_document_count(),

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -1,7 +1,8 @@
 import logging
 
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 
+from core.auth import require_auth
 from core.config import config
 from middleware.rate_limit import limiter
 
@@ -34,7 +35,7 @@ def _http_error(
 
 @router.post("/upload", status_code=202)
 @limiter.limit(config.RATE_LIMIT_UPLOAD)
-async def upload(request: Request, file: UploadFile = File(...)):
+async def upload(request: Request, file: UploadFile = File(...), auth: dict = Depends(require_auth)):
     """
     Accept a file upload, validate it, and enqueue it for background processing.
 

--- a/backend/services/answer_service.py
+++ b/backend/services/answer_service.py
@@ -15,16 +15,21 @@ from services.providers.base import (
 logger = logging.getLogger(__name__)
 
 
-def _load_system_prompt() -> str:
+_SYSTEM_PROMPT: str | None = None
+
+
+def _get_system_prompt() -> str:
+    global _SYSTEM_PROMPT
+    if _SYSTEM_PROMPT is not None:
+        return _SYSTEM_PROMPT
     path = Path(config.SYSTEM_PROMPT_PATH)
     if not path.is_file():
         raise FileNotFoundError(
-            f"System prompt file not found at {path} (SYSTEM_PROMPT_PATH is set but the file is missing)."
+            f"System prompt file not found at {path} "
+            f"(SYSTEM_PROMPT_PATH={config.SYSTEM_PROMPT_PATH!r})."
         )
-    return path.read_text(encoding="utf-8").strip()
-
-
-_SYSTEM_PROMPT = _load_system_prompt()
+    _SYSTEM_PROMPT = path.read_text(encoding="utf-8").strip()
+    return _SYSTEM_PROMPT
 
 LLM_MSG_MISSING_API_KEY = (
     "LLM service is not available: API key is missing or not configured."
@@ -94,7 +99,7 @@ async def generate_answer(question: str, context: str) -> str:
         provider = get_llm_provider()
         answer = await provider.generate(
             contents,
-            system_instruction=_SYSTEM_PROMPT,
+            system_instruction=_get_system_prompt(),
             temperature=config.LLM_TEMPERATURE,
             max_output_tokens=config.LLM_MAX_OUTPUT_TOKENS,
         )

--- a/backend/services/context_service.py
+++ b/backend/services/context_service.py
@@ -1,6 +1,9 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+
+MAX_CONTEXT_CHARS: int = int(os.getenv("MAX_CONTEXT_CHARS", "32000"))
 
 
 def build_context_from_chunks(chunks: list) -> str:
@@ -9,14 +12,37 @@ def build_context_from_chunks(chunks: list) -> str:
 
     Each chunk is prefixed with a source label so the model can cite
     the originating file and page in its answer.
+
+    Chunks are dropped (whole, from the end) if the total would exceed
+    MAX_CONTEXT_CHARS, preserving formatting of all included chunks.
     """
     parts: list[str] = []
-    for chunk in chunks:
+    total_chars = 0
+    separator = "\n\n"
+    sep_len = len(separator)
+
+    for i, chunk in enumerate(chunks):
         label = f"[Source: {chunk.file_name or 'unknown'}"
         if chunk.page_number is not None:
             label += f", page {chunk.page_number}"
         label += "]"
-        parts.append(f"{label}\n{chunk.chunk_text or ''}")
-    context = "\n\n".join(parts)
-    logger.info(f"Constructed context of length {len(context)}")
+        part = f"{label}\n{chunk.chunk_text or ''}"
+
+        addition = (sep_len + len(part)) if parts else len(part)
+        if total_chars + addition > MAX_CONTEXT_CHARS:
+            logger.warning(
+                "Context truncated: dropped %d of %d chunks to stay within "
+                "MAX_CONTEXT_CHARS=%d (used %d chars)",
+                len(chunks) - i,
+                len(chunks),
+                MAX_CONTEXT_CHARS,
+                total_chars,
+            )
+            break
+
+        parts.append(part)
+        total_chars += addition
+
+    context = separator.join(parts)
+    logger.info("Constructed context of length %d", len(context))
     return context

--- a/backend/services/context_service.py
+++ b/backend/services/context_service.py
@@ -30,13 +30,21 @@ def build_context_from_chunks(chunks: list) -> str:
 
         addition = (sep_len + len(part)) if parts else len(part)
         if total_chars + addition > MAX_CONTEXT_CHARS:
+            if not parts:
+                # Single chunk exceeds cap; include it rather than returning empty context.
+                parts.append(part)
+                dropped = len(chunks) - i - 1
+                used = len(part)
+            else:
+                dropped = len(chunks) - i
+                used = total_chars
             logger.warning(
                 "Context truncated: dropped %d of %d chunks to stay within "
                 "MAX_CONTEXT_CHARS=%d (used %d chars)",
-                len(chunks) - i,
+                dropped,
                 len(chunks),
                 MAX_CONTEXT_CHARS,
-                total_chars,
+                used,
             )
             break
 

--- a/backend/services/ingestion_pipeline.py
+++ b/backend/services/ingestion_pipeline.py
@@ -644,6 +644,8 @@ def _sanitize_filename(name: str | None, max_length: int = 255) -> str:
     name = pathlib.Path(name or "").name
     name = re.sub(r"[^\w \-.]", "", name)
     name = name.strip()[:max_length]
+    if name in (".", ".."):
+        return "upload"
     return name or "upload"
 
 

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -15,6 +15,8 @@ from services.providers.base import EmbeddingProvider, LLMProvider
 logger = logging.getLogger(__name__)
 
 # Singletons — public so tests can reset them (same pattern as db.db_service).
+# NOTE: Phase 3 will require per-tenant or per-request provider instances.
+# Current singleton pattern will be replaced.
 _embedding_provider: EmbeddingProvider | None = None
 _llm_provider: LLMProvider | None = None
 

--- a/backend/tests/test_chat_route.py
+++ b/backend/tests/test_chat_route.py
@@ -5,6 +5,9 @@ from unittest.mock import AsyncMock, patch
 from request_utils import make_test_request
 from routes.chat import ChatBatchItem, ChatBatchRequest, ChatRequest, chat, chat_batch
 
+_DOC_ID_1 = "00000000-0000-0000-0000-000000000001"
+_DOC_ID_2 = "00000000-0000-0000-0000-000000000002"
+
 
 def test_chat_route_delegates_to_chat_service():
     payload = {"question": "q", "chunks": 1, "answer": "a"}
@@ -13,12 +16,12 @@ def test_chat_route_delegates_to_chat_service():
         result = asyncio.run(
             chat(
                 make_test_request("POST", "/chat"),
-                ChatRequest(question="q", doc_id="doc-xyz"),
+                ChatRequest(question="q", doc_id=_DOC_ID_1),
             )
         )
 
     assert result == payload
-    mock_chat.assert_awaited_once_with(question="q", doc_id="doc-xyz", match_count=5)
+    mock_chat.assert_awaited_once_with(question="q", doc_id=_DOC_ID_1, match_count=5)
 
 
 def test_chat_batch_route_delegates_to_chat_service():
@@ -26,9 +29,9 @@ def test_chat_batch_route_delegates_to_chat_service():
         "count": 1,
         "success_count": 1,
         "failure_count": 0,
-        "results": [{"status": "ok", "question": "q", "doc_ids": ["doc-1"], "chunks": 1, "answer": "a"}],
+        "results": [{"status": "ok", "question": "q", "doc_ids": [_DOC_ID_1], "chunks": 1, "answer": "a"}],
     }
-    batch_request = ChatBatchRequest(queries=[ChatBatchItem(question="q", doc_ids=["doc-1"])])
+    batch_request = ChatBatchRequest(queries=[ChatBatchItem(question="q", doc_ids=[_DOC_ID_1])])
 
     with patch(
         "routes.chat.answer_questions_for_documents_batch",
@@ -40,22 +43,22 @@ def test_chat_batch_route_delegates_to_chat_service():
 
     assert result == payload
     mock_batch.assert_awaited_once_with(
-        [{"question": "q", "doc_ids": ["doc-1"], "match_count": 5}]
+        [{"question": "q", "doc_ids": [_DOC_ID_1], "match_count": 5}]
     )
 
 
 def test_chat_batch_route_counts_failures_and_successes():
-    batch_request = ChatBatchRequest(queries=[ChatBatchItem(question="q", doc_ids=["doc-1"])])
+    batch_request = ChatBatchRequest(queries=[ChatBatchItem(question="q", doc_ids=[_DOC_ID_1])])
 
     with patch(
         "routes.chat.answer_questions_for_documents_batch",
         new=AsyncMock(
             return_value=[
-                {"status": "ok", "question": "q1", "doc_ids": ["doc-1"], "chunks": 1, "answer": "a1"},
+                {"status": "ok", "question": "q1", "doc_ids": [_DOC_ID_1], "chunks": 1, "answer": "a1"},
                 {
                     "status": "error",
                     "question": "q2",
-                    "doc_ids": ["doc-2"],
+                    "doc_ids": [_DOC_ID_2],
                     "chunks": 0,
                     "error": {"code": "query_processing_failed", "message": "boom"},
                 },
@@ -72,7 +75,7 @@ def test_chat_batch_route_counts_failures_and_successes():
 
 
 def test_chat_batch_route_returns_422_for_value_error():
-    batch_request = ChatBatchRequest(queries=[ChatBatchItem(question="q", doc_ids=["doc-1"])])
+    batch_request = ChatBatchRequest(queries=[ChatBatchItem(question="q", doc_ids=[_DOC_ID_1])])
 
     with patch(
         "routes.chat.answer_questions_for_documents_batch",

--- a/backend/tests/test_context_service.py
+++ b/backend/tests/test_context_service.py
@@ -1,0 +1,110 @@
+"""
+Tests for context_service.build_context_from_chunks.
+
+Covers:
+- Empty input
+- Normal concatenation + source labelling
+- Truncation at MAX_CONTEXT_CHARS (whole-chunk boundary, no mid-string slicing)
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from services.context_service import build_context_from_chunks
+
+
+def _chunk(text: str, file_name: str = "doc.pdf", page_number: int | None = None):
+    return SimpleNamespace(chunk_text=text, file_name=file_name, page_number=page_number)
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+def test_empty_chunks_returns_empty_string():
+    assert build_context_from_chunks([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Normal formatting
+# ---------------------------------------------------------------------------
+
+def test_single_chunk_no_page():
+    chunk = _chunk("Hello world", file_name="a.pdf")
+    result = build_context_from_chunks([chunk])
+    assert result == "[Source: a.pdf]\nHello world"
+
+
+def test_single_chunk_with_page():
+    chunk = _chunk("Hello world", file_name="a.pdf", page_number=3)
+    result = build_context_from_chunks([chunk])
+    assert result == "[Source: a.pdf, page 3]\nHello world"
+
+
+def test_multiple_chunks_joined_by_double_newline():
+    chunks = [
+        _chunk("First", file_name="a.pdf", page_number=1),
+        _chunk("Second", file_name="b.pdf", page_number=2),
+    ]
+    result = build_context_from_chunks(chunks)
+    parts = result.split("\n\n")
+    assert len(parts) == 2
+    assert parts[0] == "[Source: a.pdf, page 1]\nFirst"
+    assert parts[1] == "[Source: b.pdf, page 2]\nSecond"
+
+
+def test_unknown_file_name_fallback():
+    chunk = _chunk("text", file_name=None)
+    result = build_context_from_chunks([chunk])
+    assert "[Source: unknown]" in result
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+def test_truncation_drops_whole_chunks():
+    """All chunks that would exceed the cap are dropped entirely — no partial text."""
+    small = "x" * 100
+    chunks = [_chunk(small, file_name=f"f{i}.pdf") for i in range(10)]
+
+    # Set a cap that fits exactly 3 chunks (generous estimate; test asserts ≥ 1 dropped)
+    cap = 400
+    with patch("services.context_service.MAX_CONTEXT_CHARS", cap):
+        result = build_context_from_chunks(chunks)
+
+    # Result must be strictly shorter than or equal to cap
+    assert len(result) <= cap
+
+    # Every chunk that appears is complete — no mid-string truncation
+    for part in result.split("\n\n"):
+        assert part.endswith(small)
+
+
+def test_truncation_logs_warning(caplog):
+    chunks = [_chunk("a" * 200, file_name=f"f{i}.pdf") for i in range(5)]
+    cap = 300
+    import logging
+    with patch("services.context_service.MAX_CONTEXT_CHARS", cap):
+        with caplog.at_level(logging.WARNING, logger="services.context_service"):
+            build_context_from_chunks(chunks)
+    assert any("truncated" in record.message.lower() for record in caplog.records)
+
+
+def test_no_truncation_when_within_limit():
+    chunks = [_chunk("short", file_name=f"f{i}.pdf") for i in range(3)]
+    cap = 10_000
+    with patch("services.context_service.MAX_CONTEXT_CHARS", cap):
+        result = build_context_from_chunks(chunks)
+    assert result.count("[Source:") == 3
+
+
+def test_oversized_single_chunk_is_still_included():
+    """A single chunk larger than the cap passes through (no mid-string slicing)."""
+    big_text = "y" * 50_000
+    chunk = _chunk(big_text, file_name="big.pdf")
+    cap = 100
+    with patch("services.context_service.MAX_CONTEXT_CHARS", cap):
+        result = build_context_from_chunks([chunk])
+    assert big_text in result

--- a/backend/tests/test_prompt_config.py
+++ b/backend/tests/test_prompt_config.py
@@ -10,16 +10,18 @@ def test_load_system_prompt_returns_stripped_content(tmp_path, monkeypatch):
     prompt_file = tmp_path / "custom_system.txt"
     prompt_file.write_text("  line one\nline two  \n", encoding="utf-8")
     monkeypatch.setattr(answer_service.config, "SYSTEM_PROMPT_PATH", str(prompt_file))
+    monkeypatch.setattr(answer_service, "_SYSTEM_PROMPT", None)
 
-    assert answer_service._load_system_prompt() == "line one\nline two"
+    assert answer_service._get_system_prompt() == "line one\nline two"
 
 
 def test_load_system_prompt_missing_file_raises_clear_file_not_found(tmp_path, monkeypatch):
     missing = tmp_path / "does_not_exist.txt"
     monkeypatch.setattr(answer_service.config, "SYSTEM_PROMPT_PATH", str(missing))
+    monkeypatch.setattr(answer_service, "_SYSTEM_PROMPT", None)
 
     with pytest.raises(FileNotFoundError) as exc_info:
-        answer_service._load_system_prompt()
+        answer_service._get_system_prompt()
 
     msg = str(exc_info.value)
     assert "System prompt file not found" in msg

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -38,6 +38,9 @@ async def _rate_limit_exceeded_handler(
 _UPLOAD_WINDOW = 20
 _CHAT_WINDOW = 30
 
+# Valid document ID for POST /chat (Pydantic UUID validation).
+_CHAT_DOC_ID = "00000000-0000-0000-0000-000000000001"
+
 
 def _rate_limited_test_app() -> FastAPI:
     app = FastAPI()
@@ -77,7 +80,7 @@ def test_post_upload_returns_429_after_limit_exceeded(client):
 
 
 def test_post_chat_returns_429_after_limit_exceeded(client):
-    payload = {"question": "hello", "doc_id": "doc-1", "match_count": 5}
+    payload = {"question": "hello", "doc_id": _CHAT_DOC_ID, "match_count": 5}
     with patch(
         "routes.chat.answer_question_for_document",
         new=AsyncMock(return_value={"answer": "ok", "chunks": 0}),
@@ -106,7 +109,7 @@ def test_429_response_has_standard_error_shape(client):
 
 
 def test_429_includes_retry_after_header(client):
-    payload = {"question": "q", "doc_id": "doc-2", "match_count": 5}
+    payload = {"question": "q", "doc_id": _CHAT_DOC_ID, "match_count": 5}
     with patch(
         "routes.chat.answer_question_for_document",
         new=AsyncMock(return_value={"answer": "a", "chunks": 0}),

--- a/backend/tests/test_retry.py
+++ b/backend/tests/test_retry.py
@@ -41,16 +41,16 @@ async def test_retry_fails_on_permanent_error():
 
 @pytest.mark.asyncio
 async def test_retry_exhaustion():
-    """Should raise after max retries."""
+    """Should raise after 1 initial attempt + max_retries retries (3 total)."""
     mock_func = AsyncMock()
     mock_func.side_effect = Exception("timeout")
-    
+
     with patch('utils.retry.is_transient_error', return_value=True):
         with patch('utils.retry.asyncio.sleep', new_callable=AsyncMock):
             with pytest.raises(Exception, match="timeout"):
                 await retry_async(mock_func, max_retries=2, timeout=None)
-    
-    assert mock_func.call_count == 2
+
+    assert mock_func.call_count == 3  # 1 initial + 2 retries
 
 @pytest.mark.asyncio
 async def test_exponential_backoff():
@@ -125,7 +125,7 @@ async def test_timeout_error_after_max_retries_exhausted():
                     func_name="test.always_timeout",
                 )
 
-    assert mock_inner.call_count == 2
+    assert mock_inner.call_count == 3  # 1 initial + 2 retries
 
 @pytest.mark.asyncio
 async def test_timeout_none_skips_wait_for():

--- a/backend/utils/retry.py
+++ b/backend/utils/retry.py
@@ -6,7 +6,7 @@ Example:
 
     result = await retry_async(
         lambda: service.save(payload),
-        max_retries=3,
+        max_retries=3,      # up to 3 retries after the first attempt (4 total)
         base_delay=1.0,
         backoff=2.0,
         timeout=10.0,
@@ -72,8 +72,9 @@ async def retry_async(
         func_name = getattr(func, '__name__', 'unknown_function')
 
     last_exception = None
+    max_attempts = max_retries + 1
 
-    for attempt in range(max_retries):
+    for attempt in range(max_attempts):
         try:
             if timeout is not None:
                 return await asyncio.wait_for(func(), timeout=timeout)
@@ -81,27 +82,27 @@ async def retry_async(
                 return await func()
         except asyncio.TimeoutError as e:
             last_exception = e
-            if attempt == max_retries - 1:
+            if attempt == max_attempts - 1:
                 logger.error(
-                    f"Final retry attempt timed out for {func_name}",
+                    f"Final attempt timed out for {func_name}",
                     extra={
                         "error_type": "TimeoutError",
                         "timeout_seconds": timeout,
                         "attempt": attempt + 1,
-                        "max_retries": max_retries,
+                        "max_attempts": max_attempts,
                     },
                 )
                 raise
             cap = base_delay * (backoff ** attempt)
             delay = random.uniform(0, cap)
             logger.warning(
-                f"Attempt {attempt + 1}/{max_retries} timed out for "
+                f"Attempt {attempt + 1}/{max_attempts} timed out for "
                 f"{func_name} after {timeout}s, retrying in {delay:.2f}s",
                 extra={
                     "error_type": "TimeoutError",
                     "timeout_seconds": timeout,
                     "attempt": attempt + 1,
-                    "max_retries": max_retries,
+                    "max_attempts": max_attempts,
                     "next_retry_delay": delay,
                 },
             )
@@ -117,19 +118,19 @@ async def retry_async(
                         "error_type": type(e).__name__,
                         "error_message": str(e),
                         "attempt": attempt + 1,
-                        "max_retries": max_retries,
+                        "max_attempts": max_attempts,
                     }
                 )
                 raise
 
-            if attempt == max_retries - 1:
+            if attempt == max_attempts - 1:
                 logger.error(
-                    f"Final retry attempt failed for {func_name}",
+                    f"Final attempt failed for {func_name}",
                     extra={
                         "error_type": type(e).__name__,
                         "error_message": str(e),
                         "attempt": attempt + 1,
-                        "max_retries": max_retries,
+                        "max_attempts": max_attempts,
                     }
                 )
                 raise
@@ -139,12 +140,12 @@ async def retry_async(
 
             logger.warning(
                 f"Transient error in {func_name}, "
-                f"retrying in {delay:.2f}s (attempt {attempt + 1}/{max_retries})",
+                f"retrying in {delay:.2f}s (attempt {attempt + 1}/{max_attempts})",
                 extra={
                     "error_type": type(e).__name__,
                     "error_message": str(e),
                     "attempt": attempt + 1,
-                    "max_retries": max_retries,
+                    "max_attempts": max_attempts,
                     "next_retry_delay": delay,
                 }
             )


### PR DESCRIPTION
## Summary

Targeted backend hardening before Phase 3 (auth, multi-tenancy, sessions, streaming). No architectural refactors—minimal, surgical changes for correctness, safety, and extension points.

## Commits

1. **Phase 3 preflight polish**: remove dead SQLAlchemy engine from `core/models.py`, bounded LLM context (`MAX_CONTEXT_CHARS`), UUID validation on chat/documents routes, fix `retry_async` semantics (`max_retries` = retries after first attempt), `LOG_LEVEL` wired in logging setup, lazy/cached system prompt load, Phase 3 note on provider singletons, filename sanitize edge cases (`'.'`, `'..'`), retry tests updated.

2. **Final preflight**: idempotent `update_document_status` in SQLAlchemy when document missing (warn + return), `MAX_CONTEXT_CHARS` + NLTK note in `.env.example`, `core/auth.py` stub + `Depends(require_auth)` on all route handlers (no enforcement), context truncation edge case (oversized single chunk included; accurate warning counts), `test_context_service.py`, chat/prompt test fixes for UUID + `_get_system_prompt`.

## Behavioral notes

- Retry: one extra attempt per configured `max_retries` (fixes prior off-by-one).
- Invalid non-UUID `doc_id` / `document_id`: 422 (FastAPI/Pydantic).
- `update_document_status` missing doc: no longer raises `ValueError` (SQLAlchemy; aligns with Supabase no-op).
- Context may be truncated by dropping whole chunks; first chunk still included if alone over cap.
- System prompt: loaded on first use, not at import.
- `require_auth` returns `{"tenant_id": None}` only—wiring for Phase 3.

## Testing

- `pytest` for affected modules (full suite may need `redis`, DB, etc. in CI).