### PR TITLE
docs: update documentation for Phase 2.5 completion and Phase 3 kickoff

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,8 +153,9 @@ An async in-memory `asyncio.Queue` decouples upload from processing.
 Documents left in any in-progress state are bulk-updated to `failed`
 before workers start accepting new jobs.
 
-> **Note:** The queue will be replaced with Redis (#123) for job
-> durability and multi-instance support.
+> **Note:** The default queue is in-memory. A Redis-backed queue is
+> implemented (`QUEUE_BACKEND=redis`) and will become the production
+> default in Phase 3 for job durability and multi-instance support.
 
 ---
 
@@ -217,6 +218,7 @@ All external I/O is wrapped with retry logic via `backend/utils/retry.py`.
 - `asyncio.TimeoutError` caught by type and always treated as transient
 - 429/rate-limit errors from Gemini detected by type (`APIError`) before string matching
 - Non-transient errors (4xx validation failures) fail fast without retry
+- `max_retries` means retries *after* the first attempt — `max_retries=3` makes 4 total attempts
 
 **Timeout configuration:**
 | Surface | Timeout | Mechanism |
@@ -248,8 +250,9 @@ Per-IP HTTP rate limiting via `slowapi` on all public endpoints.
 All limits are configurable via env vars (`RATE_LIMIT_*`).
 429 responses return `{"detail": {"code": "rate_limited", "message": "..."}}`.
 
-Storage is in-memory for single-instance deployments. Migration to
-Redis-backed storage is planned when #123 lands.
+Storage is in-memory for single-instance deployments. Redis-backed
+rate limit storage will be introduced in Phase 3 alongside the Redis
+queue promotion.
 
 ---
 
@@ -273,7 +276,9 @@ rejected at startup when `allow_credentials=True`.
 
 **Input validation** — Pydantic field bounds on all chat endpoints:
 `max_length=2000` on questions, `le=20` on `match_count`, `max_length=20`
-on batch queries.
+on batch queries. Document IDs (`doc_id`, `document_id`) are validated
+as UUIDs at the route layer — invalid values return 422 before reaching
+the service or DB layer.
 
 **OpenAPI docs** — `/docs`, `/redoc`, and `/openapi.json` disabled when
 `APP_ENV=production`.
@@ -408,7 +413,7 @@ responses. Security headers on every response.
 The current architecture supports these extensions without major refactors:
 
 - ~~Pluggable LLM & embedding providers~~ (done — see LLM & Embedding Providers)
-- **Redis-backed queue** — drop-in replacement for in-memory queue (#123)
+- ~~Redis-backed queue~~ (implemented — `QUEUE_BACKEND=redis`; in-memory remains default until Phase 3)
 - **Authentication & multi-tenancy** — Phase 3
 - **Streaming LLM responses** — Server-Sent Events, Phase 3
 - **Specialized pipelines** — legal, academic, code document handling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,8 @@ This document focuses on contribution rules and expectations.
 
 🎯 Before Submitting
 
-1. Test your changes manually using FastAPI /docs
-2. Verify existing functionality still works
-3. Check your code runs without errors
-4. Update documentation if needed
+1. Run the test suite and confirm it passes: `make tests` (Docker) or `cd backend && pytest tests/ -v`
+2. Test your changes manually using FastAPI `/docs`
+3. Verify existing functionality still works
+4. Check your code runs without errors
+5. Update documentation if needed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -193,8 +193,9 @@ Inspect the dead-letter queue at any time:
 curl http://localhost:8000/queue/stats
 ```
 
-> **Note:** The current queue is in-memory and does not persist across
-> restarts. Redis-backed durability is planned in [#123](https://github.com/chatvector-ai/chatvector-ai/issues/123).
+> **Note:** The current default queue is in-memory and does not persist across
+> restarts. A Redis-backed queue is implemented and available (`QUEUE_BACKEND=redis`);
+> it will become the production default in Phase 3.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for full queue and pipeline details.
 
@@ -214,8 +215,11 @@ docker compose run --rm tests
 
 ### Running Locally
 
-`backend/requirements.txt` installs `psycopg[binary]`, so local pytest
-collection does not require a separate system `libpq` installation.
+`backend/requirements.txt` installs `psycopg[binary]`, which bundles
+the Postgres client library for most platforms. On Python 3.13 or
+non-standard environments `psycopg_binary` may not be available; if you
+see `libpq library not found` errors, run tests via Docker instead
+(`make tests`) or install `libpq` and `psycopg[c]` manually.
 
 ```bash
 cd backend
@@ -281,6 +285,7 @@ Docker Compose expands `${VAR}` from your process environment or a
 | `POSTGRES_DB`         | **Required** | As above                                                        |
 | `LOG_LEVEL`           | Optional     | Default: `INFO`                                                 |
 | `LOG_FORMAT`          | Optional     | `TEXT` or `JSON` (default: `TEXT`; use `JSON` for log shipping) |
+| `MAX_CONTEXT_CHARS`   | Optional     | Max chars of retrieved context sent to LLM; default `32000`     |
 | `QUEUE_WORKER_COUNT`  | Optional     | Default: `3`                                                    |
 | `QUEUE_EMBEDDING_RPS` | Optional     | Default: `2.0`                                                  |
 | `LLM_HTTP_TIMEOUT_MS` | Optional     | Default: `60000`                                                |
@@ -322,8 +327,10 @@ docker compose up --build
 
 ### Queue persistence
 
-The current in-memory queue does not persist across restarts. Plan
-for this in production deployments until Redis (#123) lands.
+The default in-memory queue does not persist across restarts. For production
+deployments requiring durability, set `QUEUE_BACKEND=redis` and provide
+`REDIS_URL`. Redis queue support is implemented; it will become the default
+in Phase 3.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ ChatVector is designed for:
 
 ## 🚀 Current Status
 
-### Phase 2 — Largely Complete
+### Phase 2 & 2.5 — Complete | Phase 3 — In Progress
 
-The core RAG backend and frontend demo are fully functional. Phase 2 focused on developer experience, retrieval quality, and production hardening.
+Phases 2 and 2.5 are complete. The core RAG backend and frontend demo are fully functional and hardened. Phase 3 is now underway, adding authentication, multi-tenancy, sessions, and streaming.
 
 **What's working today:**
 
@@ -99,11 +99,14 @@ The core RAG backend and frontend demo are fully functional. Phase 2 focused on 
 - ✅ Query transformations (rewrite, expand, stepback)
 - ✅ Configurable system prompt and LLM parameters
 - ✅ Background ingestion queue with rate limiting, retry, and DLQ
+- ✅ Redis-backed ingestion queue (implemented; in-memory remains the default)
 - ✅ Structured logging with request ID tracing
 - ✅ Health checks with TTL caching on /status
 - ✅ Per-IP rate limiting on all public endpoints
+- ✅ UUID validation on all document ID inputs
 - ✅ Security headers, CORS hardening, input validation
 - ✅ Production Compose config + GitHub Actions CI
+- ✅ Pluggable LLM & embedding providers (Gemini, OpenAI, Ollama)
 - ✅ Python client SDK
 
 **Frontend Demo**
@@ -113,10 +116,10 @@ The core RAG backend and frontend demo are fully functional. Phase 2 focused on 
 - ✅ Responsive design with dark developer aesthetic
 
 **In progress / Phase 3:**
-- 🚧 Redis-backed durable ingestion queue (#123)
-- ✅ Pluggable LLM & embedding providers (Gemini, OpenAI, Ollama)
-- 🚧 Authentication & multi-tenancy
-- 🚧 Streaming LLM responses
+- 🚧 Authentication & multi-tenancy (API key per tenant)
+- 🚧 Session-based chat with conversation memory
+- 🚧 Streaming LLM responses (SSE)
+- 🚧 Redis queue promoted to production default
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,71 +4,246 @@ This document outlines the current development focus and future direction of the
 
 ---
 
-## ✅ Phase 1: Stabilize & Optimize Core Engine (Complete)
+## ✅ Phase 1 — Core Engine Stabilization (Complete)
 
-Phase 1 focused on hardening the RAG backend for reliability, observability, and performance. All core work is shipped.
+Phase 1 focused on building and hardening the foundational RAG pipeline.
 
-**What shipped:**
+**Delivered**
 
-- Ingestion pipeline robustness and error handling
-- Async/batch processing foundations
-- Embedding queue for production scaling
-- Centralized retry utility
+- Document ingestion pipeline (PDF, text)
+- Chunking strategies (fixed, paragraph)
+- Embedding + vector storage via pgvector
+- Retrieval + LLM answer generation with source citations
+- Centralized retry utility with backoff
+- Background ingestion queue
 - Advanced logging and request ID middleware
-- Chunk metadata, chunk tuning, and source citation support
-- Real system metrics on /status endpoint
-- Terminology standardized to "ingestion" throughout
-- POST /chat migrated to JSON request body
+- `/status` endpoint with live system metrics
+- JSON-based `POST /chat` API
 - LLM error handling with distinct error classification
 - Upload pipeline refactored into dedicated service layer
 
+**Outcome:** A stable, production-capable stateless RAG backend engine.
+
 ---
 
-## ✅ Phase 2: Enhance Developer Experience (Largely Complete)
+## ✅ Phase 2 — Capability Expansion & Developer Experience (Complete)
 
-Phase 2 focused on expanding capabilities, improving retrieval quality, hardening the backend for production, and delivering a working end-to-end frontend demo.
-
-**What shipped:**
+Phase 2 expanded flexibility, retrieval quality, and usability while maintaining backend-first design.
 
 **Backend**
-- Advanced chunking strategies — fixed, paragraph, and semantic chunking with configurable strategy via env
-- Query transformations — rewrite, expand, and stepback strategies between user input and vector search
-- Prompt tuning & system prompt configuration — externalized system prompt and LLM parameters
-- Python client SDK — lightweight SDK wrapping core API endpoints with typed models and error handling
-- Observability — embedding and LLM health checks on /status, structured log shipping guide, access log persistence
-- Deployment improvements — production Compose config, GitHub Actions CI pipeline, deployment documentation
-- API rate limiting — per-IP rate limiting on all public endpoints via slowapi
-- Retry utility hardening — per-attempt timeouts, jitter, 429-aware retries, queue job backoff
-- Resilience hardening — LLM HTTP timeouts, SQLAlchemy statement timeout, Supabase client timeouts
-- Health check caching — in-memory TTL cache for embedding and LLM health checks on /status
-- Security hardening — security headers middleware, CORS tightening, upload filename sanitization, MIME validation, input bounds, error message leakage prevention, docs disabled in production
 
-**Frontend**
-- Homepage redesign — sharp, technical landing page with hero, features, pipeline, and developer sections
-- Navbar redesign — responsive navbar with mobile drawer, active states, and GitHub CTA
-- Chat page — full end-to-end demo: document upload, ingestion status polling, live pipeline stage display, and real RAG-powered chat
-- Backend integration — POST /chat wired up with loading state, inline errors, and source citations
-- Design system — tokens documented in globals.css, Tailwind conventions established
+- Advanced chunking strategies (fixed, paragraph, semantic)
+- Query transformations (rewrite, expand, stepback)
+- Prompt tuning and system prompt configuration
+- Pluggable LLM and embedding providers (Gemini, OpenAI, Ollama)
+- Per-IP rate limiting via slowapi
+- LLM + embedding health checks on `/status`
+- Observability improvements and structured logging guide
+- Production Docker Compose and GitHub Actions CI pipeline
+- Security hardening (headers, CORS, upload validation, error handling)
+- Python client SDK with typed models and retry handling
+- Redis-backed ingestion queue (implemented, not yet default in production)
 
-**Still in progress / open for contributors**
-- Redis-backed durable ingestion queue — replace in-memory queue for job durability and multi-worker support
+**Frontend Demo**
 
----
+- End-to-end RAG chat interface
+- Document upload + ingestion status tracking
+- Source citations display
+- Typing effect, light/dark theme toggle
+- Responsive navbar and homepage redesign
 
-## 🏗 Phase 3: Scale & Specialize (Next)
-
-Focus: Production-ready document intelligence platform.
-
-- **Authentication & multi-tenancy** — gate all endpoints including /queue/stats; add tenant model across upload, chat, and queue
-- **Pluggable LLM & embedding providers** — support Gemini, OpenAI, and Ollama via env config
-- **Streaming LLM responses** — token-by-token streaming via Server-Sent Events
-- **Specialized pipelines** — legal, academic, or code document handling
-- **Ecosystem growth** — community integrations, example applications
-- **Frontend maturity** — full documentation site with live API explorer and community showcase gallery
+**Outcome:** A flexible, developer-friendly RAG backend with strong defaults and a working demo.
 
 ---
 
-## 📌 Notes
+## ✅ Phase 2.5 — Hardening & Consistency Layer (Complete)
 
-- Issue status (blocked, in progress, etc.) is visible when you click through to GitHub.
-- This roadmap provides a quick overview; click any issue for full details.
+A focused stabilization pass based on a backend audit conducted ahead of Phase 3.
+
+**Delivered**
+
+- Unified API error contract across `/chat` and `/chat/batch`
+- Provider timeout standardization (LLM + embeddings)
+- Embedding validation — no silent dimension fallbacks
+- Logging safety improvements — no sensitive payload leakage
+- Queue consistency improvements and documentation alignment
+- Supabase delete atomicity (transaction/RPC-based)
+- Expanded test coverage for core flows
+- Config and `.env` alignment with runtime behavior
+
+**Outcome:** A production-ready, internally consistent backend ready for architectural expansion.
+
+---
+
+## 🚧 Phase 3 — Platform Evolution (In Progress)
+
+### North Star
+
+Transform ChatVector into a **multi-tenant, session-aware document intelligence backend** while preserving a simple, plug-and-play developer experience.
+
+**Core Principle:** Simple by default, powerful when explicitly enabled.
+
+---
+
+### Phase 3A — Core Platform Foundation
+
+This phase introduces the primary architectural shift. All Phase 3B and 3C work depends on this foundation.
+
+#### 1. API Authentication & Multi-Tenancy
+
+- API key (`Bearer <API_KEY>`) required for all endpoints
+- Each API key maps 1:1 to a tenant — implicit and strict
+- All resources (documents, sessions, queries, ingestion jobs) automatically scoped to tenant
+- Per-tenant rate limiting replaces per-IP limiting
+- No user accounts or auth flows — API-level only
+- No tenant overrides accepted in request bodies
+
+#### 2. Session-Based Chat (Document-Scoped)
+
+- Sessions provide conversation memory and document query scope
+- Auto-created if no `session_id` is provided — zero config required
+- Sessions bound to a specific set of documents at creation
+- Full message history persisted per session (user and assistant turns)
+- Optional `external_user_id` field for developer-side user mapping
+- Explicit session management endpoints: create, list, delete
+
+#### 3. Context Injection Strategy
+
+- Conversation history is used to improve query rewriting and expansion
+- Retrieval operates on a clean, transformed query — not raw history
+- LLM receives: top-k retrieved chunks + a small recent message window
+- Prevents token explosion and retrieval quality degradation over long sessions
+
+#### 4. Streaming LLM Responses
+
+- SSE endpoint at `/chat/stream` for token-by-token streaming
+- Final structured event includes citations and source metadata
+- Session message persisted after stream completes
+
+#### 5. Redis Queue as Production Default
+
+- Redis-backed ingestion queue promoted to default in production environments
+- In-memory queue retained as development fallback
+- Documentation and configuration aligned
+
+---
+
+### Phase 3B — Quality & Ecosystem
+
+Build on the platform foundation to improve response quality and expand developer reach.
+
+#### 6. Configurable Response Personas
+
+- Predefined system prompt styles: `default`, `conversational`, `academic`, `technical`, `concise`
+- Configured via `PROMPT_PERSONA` environment variable
+- Clear precedence: custom prompt path > persona > default system prompt
+- No pipeline changes required — prompt engineering only
+
+#### 7. Additional Provider Support
+
+- Claude (LLM-only — Anthropic has no embeddings API)
+- Voyage AI (embeddings — includes domain-tuned models)
+- Explicit support and documentation for mixed-provider setups (e.g. Claude + Voyage)
+
+#### 8. Scoped Retrieval with Optional Tenant-Wide Querying
+
+- Default behavior: retrieval scoped to session documents
+- Optional `scope: "tenant"` parameter enables search across all tenant documents
+- Opt-in only — clearly documented with cost and latency implications
+
+```json
+{
+  "question": "What do we know about pricing?",
+  "scope": "tenant"
+}
+```
+
+#### 9. Node.js / TypeScript SDK
+
+- First-class SDK for backend developers
+- Typed API client, retry with backoff, `waitForReady()` polling helper
+- Session-aware chat support
+- Published to npm
+
+---
+
+### Phase 3C — Polish & Adoption
+
+Focus on documentation, discoverability, and real-world integration patterns.
+
+#### 10. Documentation Site
+
+- Getting started guide
+- API reference generated from OpenAPI schema
+- SDK documentation (Python + Node)
+- Deployment guides (self-hosted and cloud)
+
+#### 11. Live API Explorer
+
+- Swagger UI or Scalar integration
+- Try-it-out functionality for all endpoints
+- Enabled in non-production environments only
+
+#### 12. Example Applications
+
+- At least two reference implementations:
+  - Node.js backend using the Node SDK
+  - Python FastAPI backend using the Python SDK
+- Demonstrate real integration patterns, not toy examples
+
+---
+
+## 🔮 Phase 4 — Advanced Capabilities (Future)
+
+These are valuable extensions deferred until the Phase 3 platform foundation is stable.
+
+**Retrieval Quality**
+- Hybrid search (PostgreSQL full-text + vector search — BM25 + pgvector)
+- Reranking layer (cross-encoder or API-based, e.g. Cohere Rerank)
+
+**Scalability & Performance**
+- Embedding and query result caching
+- Webhook-based ingestion callbacks
+- Advanced rate limiting and usage tracking
+
+**Data & Document Management**
+- Document versioning
+- Retrieval feedback signals (thumbs up/down on answers)
+- Multi-format document ingestion (e.g. Docling — DOCX, PPTX, HTML, images)
+
+**Advanced Retrieval**
+- Knowledge graph and GraphRAG approaches
+- Domain-specific pipelines (legal, academic, code-aware)
+
+**Ecosystem**
+- React SDK
+- Community showcase and integrations gallery
+
+---
+
+## ❌ Non-Goals
+
+ChatVector is intentionally **not** building the following:
+
+| Item | Reason |
+|------|--------|
+| User authentication (login/signup) | Developer's responsibility at the application layer |
+| Billing or subscriptions | Out of scope for an open-source backend engine |
+| Collaborative workspaces | Different product category |
+| Admin dashboards | Not needed for a developer tool |
+| Full SaaS product layer | Conflicts with backend-first positioning |
+| Elasticsearch dependency | pgvector + PostgreSQL full-text covers the same ground at this scale |
+
+---
+
+## Phase 3 Success Criteria
+
+By the end of Phase 3, ChatVector should be:
+
+- ✅ A secure, multi-tenant RAG API accessed via API key
+- ✅ Capable of stateful document conversations with session memory
+- ✅ Streaming-first with modern chatbot UX
+- ✅ Provider-flexible — mix and match LLMs and embedding models
+- ✅ Simple to use by default, powerful when advanced features are enabled
+- ✅ Supported by SDKs in Python and Node.js
+- ✅ Backed by real example applications and comprehensive documentation


### PR DESCRIPTION
## Summary

Documentation pass to mark Phase 2 and 2.5 as complete and reflect Phase 3 in progress. All changes are doc-only — no code touched.

- **README.md** — Current status reflects Phase 2 & 2.5 complete / Phase 3 in progress; added Redis queue and UUID validation to completed list; rewrote Phase 3 in-progress section (auth, sessions, streaming, Redis default); removed stale checkmark
- **DEVELOPMENT.md** — Redis queue notes updated from "planned" to "implemented, not default"; queue persistence section references `QUEUE_BACKEND=redis`; local pytest note warns Python 3.13 may hit `libpq` issues and recommends `make tests`; `MAX_CONTEXT_CHARS` added to production env vars table
- **ARCHITECTURE.md** — Redis queue entry in Extension Path struck through (shipped); Ingestion Queue and Rate Limiting "planned" notes updated to reflect current state; UUID enforcement on `doc_id`/`document_id` documented in Input Validation; `max_retries` semantics clarified in Retry Logic
- **CONTRIBUTING.md** — `make tests` added as step 1 in "Before Submitting" checklist
- **ROADMAP.md** — Phase 3 marked in progress (updated separately by maintainer)

## Test plan
- [ ] Verify all links in README and DEVELOPMENT.md still resolve
- [ ] Confirm no code changes included (doc-only PR)