### PR TITLE
feat(frontend): implement anonymous session system (closes #268)

### DIFF
--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -1,4 +1,7 @@
+import { getSessionId } from "./session";
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+export { API_BASE };
 
 export type ChatSource = {
   file_name: string;
@@ -37,12 +40,21 @@ export async function sendMessage(
   docId: string,
   matchCount = 5
 ): Promise<ChatResponse> {
+  const sessionId = getSessionId();
   let res: Response;
   try {
     res = await fetch(`${API_BASE}/chat`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ question, doc_id: docId, match_count: matchCount }),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Session-Id": sessionId,
+      },
+      body: JSON.stringify({
+        question,
+        doc_id: docId,
+        match_count: matchCount,
+        session_id: sessionId,
+      }),
     });
   } catch {
     throw new ChatError(

--- a/frontend-demo/app/lib/session.ts
+++ b/frontend-demo/app/lib/session.ts
@@ -1,0 +1,53 @@
+const SESSION_STORAGE_KEY = "chatvector_session";
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export type SessionData = {
+  id: string;
+  expiresAt: number;
+};
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).substring(2, 15);
+}
+
+export function getSessionId(): string {
+  if (typeof window === "undefined") {
+    // Return a dummy ID during SSR; hydration will use the real one if needed,
+    // but typically getSessionId is only called on user actions (like send).
+    return "ssr-session";
+  }
+
+  const now = Date.now();
+  const storedStr = localStorage.getItem(SESSION_STORAGE_KEY);
+
+  if (storedStr) {
+    try {
+      const stored = JSON.parse(storedStr) as SessionData;
+      if (stored.id && stored.expiresAt > now) {
+        // Rolling expiry: bump the expiration time
+        stored.expiresAt = now + SESSION_TTL_MS;
+        localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(stored));
+        return stored.id;
+      }
+    } catch (e) {
+      console.warn("Failed to parse session data from localStorage", e);
+    }
+  }
+
+  // Generate new session if missing, expired, or invalid
+  const newSession: SessionData = {
+    id: generateId(),
+    expiresAt: now + SESSION_TTL_MS,
+  };
+  localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(newSession));
+  return newSession.id;
+}
+
+export function resetSession(): void {
+  if (typeof window !== "undefined") {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  }
+}


### PR DESCRIPTION
## Summary
This PR implements the foundational client-side anonymous session system as required for Phase 3A. It provisions a rolling UUID for each visitor, storing it securely in `localStorage` with a 24-hour TTL. This session ID is seamlessly attached to all backend `/chat` requests.

## What changed
* **Session Helper (`frontend-demo/app/lib/session.ts`):** 
  * Implemented `getSessionId()`, which handles reading, validating, expiring, and generating the `chatvector_session` UUID in `localStorage`. It automatically bumps the 24-hour expiry threshold whenever accessed (rolling expiry).
  * Implemented `resetSession()` to clear the storage.
  * Safely handles SSR by returning a dummy string when `window` is undefined, preventing hydration mismatches.
* **API Client (`frontend-demo/app/lib/api.ts`):** 
  * Integrated `getSessionId()` into `sendMessage()`.
  * The session ID is now injected into both the JSON body payload (`session_id`) and the HTTP headers (`X-Session-Id`) on every chat submission.

## Why this matters
Because we deliberately avoid a heavy user-authentication system, we need an anonymous identifier to group a user's uploaded documents and chat messages together on the backend. This enables multi-session awareness and prepares us to safely partition databases.

## Test coverage
* Confirmed UUID generation and `localStorage` persistence.
* Validated rolling expiry time-bump logic on repeated accesses.
* Checked network payload/headers in developer tools; verified `session_id` and `X-Session-Id` are sent.
* Passed `npm run lint` and `npm run build`.

Closes #268