### PR TITLE
feat(frontend): persistent ingestion pipeline progress UI

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -86,6 +86,7 @@ export default function ChatPage() {
                 ? {
                     status: attachment.status,
                     stage: poll.stage,
+                    completedStages: poll.completedStages,
                     chunks: poll.chunks,
                   }
                 : null

--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -86,7 +86,6 @@ export default function ChatPage() {
                 ? {
                     status: attachment.status,
                     stage: poll.stage,
-                    completedStages: poll.completedStages,
                     chunks: poll.chunks,
                   }
                 : null

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Check, Loader2, AlertCircle } from "lucide-react";
+import { PIPELINE_STAGES, PIPELINE_STAGE_LABELS } from "../lib/stageLabels";
+
+type StageState = "completed" | "active" | "pending" | "failed";
+
+type Props = {
+  /** Current in-progress stage key (e.g. "chunking"). Undefined while awaiting first event. */
+  currentStage: string | undefined;
+  /** Set of stage keys that have already finished. */
+  completedStages: string[];
+  /** Whether the overall ingestion failed. */
+  failed?: boolean;
+  /** Chunk info surfaced during embedding stage. */
+  chunks?: { total: number; processed: number };
+};
+
+function getStageState(
+  stageKey: string,
+  currentStage: string | undefined,
+  completedStages: string[],
+  failed: boolean
+): StageState {
+  if (completedStages.includes(stageKey)) return "completed";
+  if (stageKey === "completed" && currentStage === "completed" && !failed)
+    return "completed";
+  if (stageKey === currentStage) return failed ? "failed" : "active";
+  return "pending";
+}
+
+function StageRow({
+  stageKey,
+  label,
+  state,
+  isLast,
+  chunks,
+}: {
+  stageKey: string;
+  label: string;
+  state: StageState;
+  isLast: boolean;
+  chunks?: { total: number; processed: number };
+}) {
+  const showChunks =
+    stageKey === "embedding" && state === "active" && chunks?.total;
+
+  return (
+    <li className="flex items-start gap-3">
+      {/* Vertical connector + icon column */}
+      <div className="flex flex-col items-center">
+        <div
+          className={[
+            "flex h-6 w-6 shrink-0 items-center justify-center rounded-full ring-1 transition-all duration-300",
+            state === "completed"
+              ? "bg-emerald-500/15 ring-emerald-400/40 text-emerald-400"
+              : state === "active"
+                ? "bg-blue/10 ring-blue/30 text-blue"
+                : state === "failed"
+                  ? "bg-red-500/10 ring-red-500/30 text-red-400"
+                  : "bg-surface ring-border text-muted/40",
+          ].join(" ")}
+        >
+          {state === "completed" && (
+            <Check size={13} strokeWidth={2.5} aria-hidden />
+          )}
+          {state === "active" && (
+            <Loader2 size={13} strokeWidth={2.5} className="animate-spin" aria-hidden />
+          )}
+          {state === "failed" && (
+            <AlertCircle size={13} strokeWidth={2} aria-hidden />
+          )}
+          {state === "pending" && (
+            <span className="h-1.5 w-1.5 rounded-full bg-muted/30" />
+          )}
+        </div>
+        {!isLast && (
+          <div
+            className={[
+              "mt-1 w-px flex-1 min-h-[1.25rem] transition-colors duration-500",
+              state === "completed" ? "bg-emerald-400/25" : "bg-border/60",
+            ].join(" ")}
+          />
+        )}
+      </div>
+
+      {/* Label */}
+      <div className="pb-4 pt-0.5">
+        <span
+          className={[
+            "text-sm font-medium leading-none transition-colors duration-200",
+            state === "completed"
+              ? "text-emerald-400"
+              : state === "active"
+                ? "text-foreground"
+                : state === "failed"
+                  ? "text-red-400"
+                  : "text-muted/50",
+          ].join(" ")}
+        >
+          {label}
+        </span>
+        {showChunks && (
+          <p className="mt-1 text-xs text-muted">
+            {chunks!.total} chunk{chunks!.total !== 1 ? "s" : ""}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default function IngestionPipeline({
+  currentStage,
+  completedStages,
+  failed = false,
+  chunks,
+}: Props) {
+  return (
+    <ul className="w-full" role="list" aria-label="Ingestion progress">
+      {PIPELINE_STAGES.map((stageKey, idx) => {
+        const state = getStageState(stageKey, currentStage, completedStages, failed);
+        const label = PIPELINE_STAGE_LABELS[stageKey];
+        const isLast = idx === PIPELINE_STAGES.length - 1;
+
+        return (
+          <StageRow
+            key={stageKey}
+            stageKey={stageKey}
+            label={label}
+            state={state}
+            isLast={isLast}
+            chunks={chunks}
+          />
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { Check, Loader2, AlertCircle } from "lucide-react";
 import { PIPELINE_STAGES, PIPELINE_STAGE_LABELS } from "../lib/stageLabels";
+
+/** ms between each incremental stage completion when fast-forwarding. */
+const STEP_MS = 380;
 
 type StageState = "completed" | "active" | "pending" | "failed";
 
@@ -15,6 +19,74 @@ type Props = {
   /** Chunk info surfaced during embedding stage. */
   chunks?: { total: number; processed: number };
 };
+
+/**
+ * When the actual stage jumps ahead by multiple steps (rapid SSE updates),
+ * this hook steps through each intermediate stage one at a time so each
+ * completion animates in sequentially instead of teleporting.
+ * When `instant` is true (e.g. on failure) it jumps directly without delays.
+ */
+function useAnimatedStage(actualStage: string | undefined, instant = false) {
+  const [displayedIdx, setDisplayedIdx] = useState(-1);
+  const displayedIdxRef = useRef(-1);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  useEffect(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+
+    const actualIdx =
+      actualStage != null ? PIPELINE_STAGES.indexOf(actualStage as never) : -1;
+
+    if (actualIdx < 0) {
+      displayedIdxRef.current = -1;
+      setDisplayedIdx(-1);
+      return;
+    }
+
+    const fromIdx = displayedIdxRef.current;
+
+    if (actualIdx <= fromIdx) return;
+
+    if (instant) {
+      displayedIdxRef.current = actualIdx;
+      setDisplayedIdx(actualIdx);
+      return;
+    }
+
+    const steps = actualIdx - fromIdx;
+    for (let s = 1; s <= steps; s++) {
+      const target = fromIdx + s;
+      if (s === 1) {
+        // Advance the first step synchronously so the active stage renders
+        // on the very first paint with no visible delay.
+        displayedIdxRef.current = target;
+        setDisplayedIdx(target);
+      } else {
+        const t = setTimeout(
+          () => {
+            displayedIdxRef.current = target;
+            setDisplayedIdx(target);
+          },
+          (s - 1) * STEP_MS
+        );
+        timersRef.current.push(t);
+      }
+    }
+
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+    };
+  }, [actualStage, instant]);
+
+  const displayedStage =
+    displayedIdx >= 0 ? PIPELINE_STAGES[displayedIdx] : undefined;
+  const displayedCompleted: string[] =
+    displayedIdx > 0 ? Array.from(PIPELINE_STAGES.slice(0, displayedIdx)) : [];
+
+  return { displayedStage, displayedCompleted };
+}
 
 function getStageState(
   stageKey: string,
@@ -112,14 +184,15 @@ function StageRow({
 
 export default function IngestionPipeline({
   currentStage,
-  completedStages,
   failed = false,
   chunks,
 }: Props) {
+  const { displayedStage, displayedCompleted } = useAnimatedStage(currentStage, failed);
+
   return (
     <ul className="w-full" role="list" aria-label="Ingestion progress">
       {PIPELINE_STAGES.map((stageKey, idx) => {
-        const state = getStageState(stageKey, currentStage, completedStages, failed);
+        const state = getStageState(stageKey, displayedStage, displayedCompleted, failed);
         const label = PIPELINE_STAGE_LABELS[stageKey];
         const isLast = idx === PIPELINE_STAGES.length - 1;
 

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -159,7 +159,7 @@ function StageRow({
       </div>
 
       {/* Label */}
-      <div className="pb-4 pt-0.5">
+      <div className="relative pb-4 pt-0.5">
         <span
           className={[
             "text-sm font-medium leading-none transition-colors duration-200",
@@ -175,7 +175,7 @@ function StageRow({
           {label}
         </span>
         {showChunks && (
-          <p className="mt-1 text-xs text-muted">
+          <p className="absolute top-full -mt-3 text-xs text-muted">
             {chunks!.total} chunk{chunks!.total !== 1 ? "s" : ""}
           </p>
         )}

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -18,6 +18,8 @@ type Props = {
   failed?: boolean;
   /** Chunk info surfaced during embedding stage. */
   chunks?: { total: number; processed: number };
+  /** Fires each time the animated displayed stage advances, including the final "completed" tick. */
+  onDisplayedStageChange?: (stage: string | undefined) => void;
 };
 
 /**
@@ -186,8 +188,16 @@ export default function IngestionPipeline({
   currentStage,
   failed = false,
   chunks,
+  onDisplayedStageChange,
 }: Props) {
   const { displayedStage, displayedCompleted } = useAnimatedStage(currentStage, failed);
+
+  const onDisplayedStageChangeRef = useRef(onDisplayedStageChange);
+  onDisplayedStageChangeRef.current = onDisplayedStageChange;
+
+  useEffect(() => {
+    onDisplayedStageChangeRef.current?.(displayedStage);
+  }, [displayedStage]);
 
   return (
     <ul className="w-full" role="list" aria-label="Ingestion progress">

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -12,8 +12,6 @@ type StageState = "completed" | "active" | "pending" | "failed";
 type Props = {
   /** Current in-progress stage key (e.g. "chunking"). Undefined while awaiting first event. */
   currentStage: string | undefined;
-  /** Set of stage keys that have already finished. */
-  completedStages: string[];
   /** Whether the overall ingestion failed. */
   failed?: boolean;
   /** Chunk info surfaced during embedding stage. */

--- a/frontend-demo/app/components/UploadButton.tsx
+++ b/frontend-demo/app/components/UploadButton.tsx
@@ -4,15 +4,17 @@ import { Paperclip } from "lucide-react";
 
 type Props = {
   onClick: () => void;
+  disabled?: boolean;
 };
 
-export default function UploadButton({ onClick }: Props) {
+export default function UploadButton({ onClick, disabled = false }: Props) {
   return (
     <button
       type="button"
-      onClick={onClick}
-      className="text-muted hover:text-foreground transition"
-      title="Upload document"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={`transition ${disabled ? "cursor-not-allowed text-muted/30" : "text-muted hover:text-foreground"}`}
+      title={disabled ? "Remove the current document before uploading a new one" : "Upload document"}
       aria-label="Upload document"
     >
       <Paperclip size={18} />

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
-import { X, Upload, Loader2, AlertCircle } from "lucide-react";
+import { X, Upload, AlertCircle } from "lucide-react";
 import { uploadDocument } from "../lib/api";
-import { STAGE_LABELS } from "../lib/stageLabels";
+import IngestionPipeline from "./IngestionPipeline";
 
 export type UploadAcceptedPayload = {
   fileName: string;
@@ -14,6 +14,7 @@ export type UploadAcceptedPayload = {
 export type UploadModalAttachment = {
   status: "processing" | "ready" | "failed";
   stage?: string;
+  completedStages?: string[];
   chunks?: { total: number; processed: number };
 };
 
@@ -97,8 +98,13 @@ export default function UploadModal({
     if (file) handleFile(file);
   };
 
-  const showFailed =
-    !isUploading && (uploadHttpFailed || attachment?.status === "failed");
+  /** HTTP-level failure: POST /upload itself returned an error. */
+  const showHttpFailed = !isUploading && uploadHttpFailed;
+  /** Server-side processing failure: document reached a failed state after upload succeeded. */
+  const showServerFailed =
+    !isUploading && !uploadHttpFailed && attachment?.status === "failed";
+  const showFailed = showHttpFailed || showServerFailed;
+
   const showProcessing =
     !showFailed &&
     !isUploading &&
@@ -115,15 +121,22 @@ export default function UploadModal({
   const dropZoneInteractive = showPicker;
   const showDismissWait = (showUploading || showProcessing) && !showSuccess;
 
+  const showPipeline = showUploading || showProcessing || showServerFailed;
+
   const dropZoneClassName = [
-    "relative min-h-[200px] rounded-2xl border-2 border-dashed p-10 flex flex-col items-center justify-center transition-all duration-300 ease-out",
+    "relative rounded-2xl border-2 border-dashed transition-all duration-300 ease-out",
+    showPipeline
+      ? "border-border bg-background px-6 py-5"
+      : "min-h-[200px] p-10 flex flex-col items-center justify-center",
     showSuccess
       ? "border-emerald-500/40 bg-emerald-500/[0.07]"
-      : showFailed
+      : showHttpFailed
         ? "border-red-500/25 bg-red-500/[0.04]"
         : dropZoneInteractive
           ? "border-border bg-surface hover:border-accent hover:bg-accent/5 cursor-pointer active:scale-[0.99]"
-          : "border-border bg-background",
+          : showPipeline
+            ? ""
+            : "border-border bg-background",
   ].join(" ");
 
   return (
@@ -200,30 +213,31 @@ export default function UploadModal({
             onChange={handleChange}
             className="hidden"
           />
-          {showUploading && (
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-blue/10 ring-1 ring-blue/20">
-                <Loader2 className="h-7 w-7 animate-spin text-blue" strokeWidth={2} />
-              </div>
-              <p className="text-base font-medium text-foreground">Uploading…</p>
-            </div>
+          {showPipeline && (
+            <IngestionPipeline
+              currentStage={showUploading ? "uploading" : attachment?.stage}
+              completedStages={
+                showUploading
+                  ? []
+                  : (attachment?.completedStages ?? [])
+              }
+              failed={showServerFailed}
+              chunks={attachment?.chunks}
+            />
           )}
-          {showProcessing && (
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-blue/10 ring-1 ring-blue/20">
-                <Loader2 className="h-7 w-7 animate-spin text-blue" strokeWidth={2} />
-              </div>
-              <p className="max-w-[280px] text-center text-base font-medium leading-snug text-foreground">
-                {attachment?.stage
-                  ? STAGE_LABELS[attachment.stage] ?? attachment.stage
-                  : "Processing your document…"}
-                {attachment?.stage === "embedding" && attachment?.chunks?.total
-                  ? ` (${attachment.chunks.total} chunks)`
-                  : ""}
-              </p>
-            </div>
+          {showServerFailed && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRetry();
+              }}
+              className="mt-4 w-full rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-surface"
+            >
+              Retry
+            </button>
           )}
-          {showFailed && (
+          {showHttpFailed && (
             <div className="flex flex-col items-center gap-4 text-center">
               <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-red-500/10 ring-1 ring-red-500/20">
                 <AlertCircle className="h-7 w-7 text-red-400" strokeWidth={1.75} aria-hidden />

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -56,7 +56,7 @@ export default function UploadModal({
 
   useEffect(() => {
     if (!showSuccess) return;
-    const timer = setTimeout(() => onCloseRef.current(), 1500);
+    const timer = setTimeout(() => onCloseRef.current(), 2500);
     return () => clearTimeout(timer);
   }, [showSuccess]);
 
@@ -121,22 +121,20 @@ export default function UploadModal({
   const dropZoneInteractive = showPicker;
   const showDismissWait = (showUploading || showProcessing) && !showSuccess;
 
-  const showPipeline = showUploading || showProcessing || showServerFailed;
+  const showPipeline = showUploading || showProcessing || showSuccess || showServerFailed;
 
   const dropZoneClassName = [
     "relative rounded-2xl border-2 border-dashed transition-all duration-300 ease-out",
     showPipeline
       ? "border-border bg-background px-6 py-5"
       : "min-h-[200px] p-10 flex flex-col items-center justify-center",
-    showSuccess
-      ? "border-emerald-500/40 bg-emerald-500/[0.07]"
-      : showHttpFailed
-        ? "border-red-500/25 bg-red-500/[0.04]"
-        : dropZoneInteractive
-          ? "border-border bg-surface hover:border-accent hover:bg-accent/5 cursor-pointer active:scale-[0.99]"
-          : showPipeline
-            ? ""
-            : "border-border bg-background",
+    showHttpFailed
+      ? "border-red-500/25 bg-red-500/[0.04]"
+      : dropZoneInteractive
+        ? "border-border bg-surface hover:border-accent hover:bg-accent/5 cursor-pointer active:scale-[0.99]"
+        : showPipeline
+          ? ""
+          : "border-border bg-background",
   ].join(" ");
 
   return (
@@ -255,22 +253,6 @@ export default function UploadModal({
               >
                 Retry
               </button>
-            </div>
-          )}
-          {showSuccess && (
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/15 ring-1 ring-emerald-400/25">
-                <svg width="22" height="22" viewBox="0 0 20 20" fill="none" aria-hidden>
-                  <path
-                    d="M4 10l4.5 4.5L16 6"
-                    stroke="#34d399"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </div>
-              <p className="text-base font-semibold text-emerald-400">Document ready!</p>
             </div>
           )}
           {showPicker && (

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -14,7 +14,6 @@ export type UploadAcceptedPayload = {
 export type UploadModalAttachment = {
   status: "processing" | "ready" | "failed";
   stage?: string;
-  completedStages?: string[];
   chunks?: { total: number; processed: number };
 };
 
@@ -61,7 +60,7 @@ export default function UploadModal({
   onCloseRef.current = onClose;
 
   // Start the close timer only once the pipeline animation visually reaches
-  // "completed" — this guarantees the 2.5s border sweep has its full duration.
+  // "completed" — this guarantees the 1.5s border sweep has its full duration.
   useEffect(() => {
     if (!pipelineVisuallyComplete) return;
     const timer = setTimeout(() => onCloseRef.current(), 1500);
@@ -262,9 +261,6 @@ export default function UploadModal({
               <div className="w-40 shrink-0">
                 <IngestionPipeline
                   currentStage={showUploading ? "uploading" : attachment?.stage}
-                  completedStages={
-                    showUploading ? [] : (attachment?.completedStages ?? [])
-                  }
                   failed={showServerFailed}
                   chunks={attachment?.chunks}
                   onDisplayedStageChange={(s) => {

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -37,11 +37,14 @@ export default function UploadModal({
   const [lastFile, setLastFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadHttpFailed, setUploadHttpFailed] = useState(false);
-  const [uploadErrorMessage, setUploadErrorMessage] = useState<string | null>(null);
+  const [uploadErrorMessage, setUploadErrorMessage] = useState<string | null>(
+    null,
+  );
   /** Until parent `attachment` reflects the new doc, avoid flashing the file picker after POST succeeds. */
   const [awaitingProcessing, setAwaitingProcessing] = useState(false);
   /** Tracks whether the pipeline animation has visually reached "completed". */
-  const [pipelineVisuallyComplete, setPipelineVisuallyComplete] = useState(false);
+  const [pipelineVisuallyComplete, setPipelineVisuallyComplete] =
+    useState(false);
 
   useEffect(() => {
     if (
@@ -57,11 +60,13 @@ export default function UploadModal({
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
+  // Start the close timer only once the pipeline animation visually reaches
+  // "completed" — this guarantees the 2.5s border sweep has its full duration.
   useEffect(() => {
-    if (!showSuccess) return;
-    const timer = setTimeout(() => onCloseRef.current(), 2500);
+    if (!pipelineVisuallyComplete) return;
+    const timer = setTimeout(() => onCloseRef.current(), 1500);
     return () => clearTimeout(timer);
-  }, [showSuccess]);
+  }, [pipelineVisuallyComplete]);
 
   const handleFile = async (file: File) => {
     setLastFile(file);
@@ -128,9 +133,11 @@ export default function UploadModal({
   // Keep "Dismiss and wait" visible until the animation visually reaches "completed",
   // not just when the raw SSE status flips to ready.
   const showDismissWait =
-    (showUploading || showProcessing || showSuccess) && !pipelineVisuallyComplete;
+    (showUploading || showProcessing || showSuccess) &&
+    !pipelineVisuallyComplete;
 
-  const showPipeline = showUploading || showProcessing || showSuccess || showServerFailed;
+  const showPipeline =
+    showUploading || showProcessing || showSuccess || showServerFailed;
 
   const dropZoneClassName = [
     "relative rounded-2xl border-2 border-dashed transition-all duration-300 ease-out",
@@ -155,9 +162,42 @@ export default function UploadModal({
       }}
     >
       <div
-        className="w-full max-w-[460px] rounded-3xl border border-border bg-surface p-6 shadow-2xl shadow-black/50"
+        className="relative w-full max-w-[460px] rounded-3xl border border-border bg-surface p-6 shadow-2xl shadow-black/50"
         onClick={(e) => e.stopPropagation()}
       >
+        {pipelineVisuallyComplete && (
+          <>
+            <style>{`
+              @property --border-sweep {
+                syntax: '<angle>';
+                initial-value: 0deg;
+                inherits: false;
+              }
+              @keyframes border-sweep {
+                to { --border-sweep: 360deg; }
+              }
+              .modal-border-sweep {
+                animation: border-sweep 1.45s linear forwards;
+                background: conic-gradient(
+                  from 180deg at 50% 50%,
+                  #34d399 0deg,
+                  #34d399 var(--border-sweep),
+                  transparent var(--border-sweep)
+                );
+                -webkit-mask:
+                  linear-gradient(#fff 0 0) content-box,
+                  linear-gradient(#fff 0 0);
+                -webkit-mask-composite: destination-out;
+                mask-composite: exclude;
+                padding: 10px;
+              }
+            `}</style>
+            <div
+              className="modal-border-sweep pointer-events-none absolute inset-0 rounded-3xl"
+              aria-hidden
+            />
+          </>
+        )}
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
@@ -223,9 +263,7 @@ export default function UploadModal({
                 <IngestionPipeline
                   currentStage={showUploading ? "uploading" : attachment?.stage}
                   completedStages={
-                    showUploading
-                      ? []
-                      : (attachment?.completedStages ?? [])
+                    showUploading ? [] : (attachment?.completedStages ?? [])
                   }
                   failed={showServerFailed}
                   chunks={attachment?.chunks}
@@ -252,7 +290,13 @@ export default function UploadModal({
                 {pipelineVisuallyComplete ? (
                   <>
                     <div className="flex h-24 w-24 items-center justify-center rounded-full bg-emerald-500/15 ring-2 ring-emerald-400/30">
-                      <svg width="44" height="44" viewBox="0 0 20 20" fill="none" aria-hidden>
+                      <svg
+                        width="44"
+                        height="44"
+                        viewBox="0 0 20 20"
+                        fill="none"
+                        aria-hidden
+                      >
                         <path
                           d="M4 10l4.5 4.5L16 6"
                           stroke="#34d399"
@@ -263,18 +307,33 @@ export default function UploadModal({
                       </svg>
                     </div>
                     <p className="text-base font-semibold leading-snug text-emerald-400">
-                      Upload<br />Successful
+                      Upload
+                      <br />
+                      Successful
                     </p>
                   </>
                 ) : (
                   <>
                     <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-blue/10 ring-1 ring-blue/20">
-                      <FileText size={28} className="text-blue" strokeWidth={1.75} aria-hidden />
+                      <FileText
+                        size={28}
+                        className="text-blue"
+                        strokeWidth={1.75}
+                        aria-hidden
+                      />
                     </div>
-                    <p className="w-full truncate text-sm font-medium text-foreground" title={lastFile?.name}>
+                    <p
+                      className="w-full truncate text-sm font-medium text-foreground"
+                      title={lastFile?.name}
+                    >
                       {lastFile?.name ?? "Document"}
                     </p>
-                    <Loader2 size={28} className="animate-spin text-muted" strokeWidth={2} aria-hidden />
+                    <Loader2
+                      size={28}
+                      className="animate-spin text-muted"
+                      strokeWidth={2}
+                      aria-hidden
+                    />
                   </>
                 )}
               </div>
@@ -283,7 +342,11 @@ export default function UploadModal({
           {showHttpFailed && (
             <div className="flex flex-col items-center gap-4 text-center">
               <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-red-500/10 ring-1 ring-red-500/20">
-                <AlertCircle className="h-7 w-7 text-red-400" strokeWidth={1.75} aria-hidden />
+                <AlertCircle
+                  className="h-7 w-7 text-red-400"
+                  strokeWidth={1.75}
+                  aria-hidden
+                />
               </div>
               <p className="max-w-[280px] text-base font-medium text-red-400">
                 {uploadErrorMessage ?? "Upload failed. Please try again."}

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -37,6 +37,7 @@ export default function UploadModal({
   const [lastFile, setLastFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadHttpFailed, setUploadHttpFailed] = useState(false);
+  const [uploadErrorMessage, setUploadErrorMessage] = useState<string | null>(null);
   /** Until parent `attachment` reflects the new doc, avoid flashing the file picker after POST succeeds. */
   const [awaitingProcessing, setAwaitingProcessing] = useState(false);
   /** Tracks whether the pipeline animation has visually reached "completed". */
@@ -66,6 +67,7 @@ export default function UploadModal({
     setLastFile(file);
     setIsUploading(true);
     setUploadHttpFailed(false);
+    setUploadErrorMessage(null);
     setPipelineVisuallyComplete(false);
     try {
       if (onBeforeUpload) {
@@ -74,8 +76,9 @@ export default function UploadModal({
       const { documentId, statusEndpoint } = await uploadDocument(file);
       onUploadAccepted({ fileName: file.name, documentId, statusEndpoint });
       setAwaitingProcessing(true);
-    } catch {
+    } catch (err) {
       setUploadHttpFailed(true);
+      setUploadErrorMessage(err instanceof Error ? err.message : null);
       setAwaitingProcessing(false);
     } finally {
       setIsUploading(false);
@@ -122,7 +125,10 @@ export default function UploadModal({
     (attachment === null || attachment.status === "ready");
 
   const dropZoneInteractive = showPicker;
-  const showDismissWait = (showUploading || showProcessing) && !showSuccess;
+  // Keep "Dismiss and wait" visible until the animation visually reaches "completed",
+  // not just when the raw SSE status flips to ready.
+  const showDismissWait =
+    (showUploading || showProcessing || showSuccess) && !pipelineVisuallyComplete;
 
   const showPipeline = showUploading || showProcessing || showSuccess || showServerFailed;
 
@@ -149,30 +155,26 @@ export default function UploadModal({
       }}
     >
       <div
-        className="w-full max-w-[580px] rounded-3xl border border-border bg-surface p-6 shadow-2xl shadow-black/50"
+        className="w-full max-w-[460px] rounded-3xl border border-border bg-surface p-6 shadow-2xl shadow-black/50"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
-            <h2 className="text-xl font-semibold tracking-tight text-foreground">
-              Upload document
-            </h2>
-            <p className="mt-1 text-base text-muted">PDF, TXT, or DOCX</p>
-            <div className="mt-1 flex min-h-[2.5rem] items-center">
-              <button
-                type="button"
-                onClick={onClose}
-                tabIndex={showDismissWait ? 0 : -1}
-                aria-hidden={!showDismissWait}
-                className={`inline-flex items-center justify-center rounded-lg px-3.5 py-2 text-sm font-medium transition ${
-                  showDismissWait
-                    ? "cursor-pointer text-muted hover:bg-background hover:text-foreground"
-                    : "pointer-events-none invisible"
-                }`}
-              >
-                Dismiss and wait
-              </button>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <h2 className="text-xl font-semibold tracking-tight text-foreground">
+                Upload document
+              </h2>
+              {showDismissWait && (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="inline-flex items-center justify-center rounded-lg px-2.5 py-1 text-sm font-medium text-muted transition hover:bg-background hover:text-foreground"
+                >
+                  Dismiss and wait
+                </button>
+              )}
             </div>
+            <p className="mt-1 mb-2 text-base text-muted">PDF, TXT, or DOCX</p>
           </div>
           <button
             type="button"
@@ -217,7 +219,7 @@ export default function UploadModal({
           {showPipeline && (
             <div className="flex gap-0">
               {/* Left — stage list */}
-              <div className="min-w-0 flex-1">
+              <div className="w-40 shrink-0">
                 <IngestionPipeline
                   currentStage={showUploading ? "uploading" : attachment?.stage}
                   completedStages={
@@ -284,7 +286,7 @@ export default function UploadModal({
                 <AlertCircle className="h-7 w-7 text-red-400" strokeWidth={1.75} aria-hidden />
               </div>
               <p className="max-w-[280px] text-base font-medium text-red-400">
-                Upload failed. Please try again.
+                {uploadErrorMessage ?? "Upload failed. Please try again."}
               </p>
               <button
                 type="button"

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
-import { X, Upload, AlertCircle } from "lucide-react";
+import { X, Upload, AlertCircle, FileText, Loader2 } from "lucide-react";
 import { uploadDocument } from "../lib/api";
 import IngestionPipeline from "./IngestionPipeline";
 
@@ -39,6 +39,8 @@ export default function UploadModal({
   const [uploadHttpFailed, setUploadHttpFailed] = useState(false);
   /** Until parent `attachment` reflects the new doc, avoid flashing the file picker after POST succeeds. */
   const [awaitingProcessing, setAwaitingProcessing] = useState(false);
+  /** Tracks whether the pipeline animation has visually reached "completed". */
+  const [pipelineVisuallyComplete, setPipelineVisuallyComplete] = useState(false);
 
   useEffect(() => {
     if (
@@ -64,6 +66,7 @@ export default function UploadModal({
     setLastFile(file);
     setIsUploading(true);
     setUploadHttpFailed(false);
+    setPipelineVisuallyComplete(false);
     try {
       if (onBeforeUpload) {
         await onBeforeUpload();
@@ -146,7 +149,7 @@ export default function UploadModal({
       }}
     >
       <div
-        className="w-full max-w-[460px] rounded-3xl border border-border bg-surface p-6 shadow-2xl shadow-black/50"
+        className="w-full max-w-[580px] rounded-3xl border border-border bg-surface p-6 shadow-2xl shadow-black/50"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-4">
@@ -212,28 +215,68 @@ export default function UploadModal({
             className="hidden"
           />
           {showPipeline && (
-            <IngestionPipeline
-              currentStage={showUploading ? "uploading" : attachment?.stage}
-              completedStages={
-                showUploading
-                  ? []
-                  : (attachment?.completedStages ?? [])
-              }
-              failed={showServerFailed}
-              chunks={attachment?.chunks}
-            />
-          )}
-          {showServerFailed && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleRetry();
-              }}
-              className="mt-4 w-full rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-surface"
-            >
-              Retry
-            </button>
+            <div className="flex gap-0">
+              {/* Left — stage list */}
+              <div className="min-w-0 flex-1">
+                <IngestionPipeline
+                  currentStage={showUploading ? "uploading" : attachment?.stage}
+                  completedStages={
+                    showUploading
+                      ? []
+                      : (attachment?.completedStages ?? [])
+                  }
+                  failed={showServerFailed}
+                  chunks={attachment?.chunks}
+                  onDisplayedStageChange={(s) => {
+                    if (s === "completed") setPipelineVisuallyComplete(true);
+                  }}
+                />
+                {showServerFailed && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRetry();
+                    }}
+                    className="mt-2 w-full rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-surface"
+                  >
+                    Retry
+                  </button>
+                )}
+              </div>
+
+              {/* Right — document status panel */}
+              <div className="flex w-48 shrink-0 flex-col items-center justify-center gap-4 text-center">
+                {pipelineVisuallyComplete ? (
+                  <>
+                    <div className="flex h-24 w-24 items-center justify-center rounded-full bg-emerald-500/15 ring-2 ring-emerald-400/30">
+                      <svg width="44" height="44" viewBox="0 0 20 20" fill="none" aria-hidden>
+                        <path
+                          d="M4 10l4.5 4.5L16 6"
+                          stroke="#34d399"
+                          strokeWidth="2.25"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+                    <p className="text-base font-semibold leading-snug text-emerald-400">
+                      Upload<br />Successful
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-blue/10 ring-1 ring-blue/20">
+                      <FileText size={28} className="text-blue" strokeWidth={1.75} aria-hidden />
+                    </div>
+                    <p className="w-full truncate text-sm font-medium text-foreground" title={lastFile?.name}>
+                      {lastFile?.name ?? "Document"}
+                    </p>
+                    <Loader2 size={28} className="animate-spin text-muted" strokeWidth={2} aria-hidden />
+                  </>
+                )}
+              </div>
+            </div>
           )}
           {showHttpFailed && (
             <div className="flex flex-col items-center gap-4 text-center">

--- a/frontend-demo/app/components/chat/ChatInput.tsx
+++ b/frontend-demo/app/components/chat/ChatInput.tsx
@@ -75,7 +75,7 @@ export default function ChatInput({
 
       <div className="bg-background px-4 py-3">
         <div className="flex items-end gap-2 bg-surface rounded-xl px-4 py-2">
-          <UploadButton onClick={onUploadClick} />
+          <UploadButton onClick={onUploadClick} disabled={!!attachment} />
           <textarea
             ref={textareaRef}
             rows={1}

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -116,6 +116,7 @@ export type AttachmentState = {
 export type DocumentStatusPayload = {
   status: string;
   stage?: string;
+  error?: { stage?: string };
   chunks?: { total: number; processed: number } | null;
 };
 
@@ -140,9 +141,15 @@ export async function getDocumentStatus(
   const stage =
     typeof stageRaw === "string" && stageRaw.length > 0 ? stageRaw : undefined;
   const chunks = parseChunks(data?.chunks);
+  const errorRaw = data?.error;
+  const error =
+    errorRaw != null && typeof errorRaw === "object"
+      ? { stage: (errorRaw as Record<string, unknown>).stage as string | undefined }
+      : undefined;
   return {
     status,
     ...(stage !== undefined ? { stage } : {}),
+    ...(error !== undefined ? { error } : {}),
     ...(chunks !== undefined ? { chunks } : {}),
   };
 }

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -166,11 +166,15 @@ export async function uploadDocument(
   });
   
   if (!res.ok) {
+    if (res.status === 429) {
+      throw new Error("Too many requests — please wait a moment and try again.");
+    }
     let message = "Upload failed. Please try again.";
     try {
       const errBody = await res.json();
       const detail = errBody?.detail;
       if (typeof detail?.message === "string") message = detail.message;
+      else if (typeof detail === "string") message = detail;
     } catch {
       /* ignore */
     }

--- a/frontend-demo/app/lib/hooks/useDocumentPolling.ts
+++ b/frontend-demo/app/lib/hooks/useDocumentPolling.ts
@@ -6,6 +6,7 @@ import {
   getDocumentStatus,
   API_BASE,
 } from "../api";
+import { PIPELINE_STAGES } from "../stageLabels";
 
 export type PolledDocumentStatus = "processing" | "ready" | "failed";
 
@@ -15,6 +16,13 @@ function mapApiStatusToUi(apiStatus: string): PolledDocumentStatus {
   return "processing";
 }
 
+/** Returns all pipeline stages that come strictly before `currentStage`. */
+function stagesBefore(currentStage: string): string[] {
+  const idx = PIPELINE_STAGES.indexOf(currentStage as never);
+  if (idx <= 0) return [];
+  return Array.from(PIPELINE_STAGES.slice(0, idx));
+}
+
 export function useDocumentPolling(
   documentId: string | undefined,
   statusEndpoint: string | undefined,
@@ -22,6 +30,7 @@ export function useDocumentPolling(
 ): {
   status: PolledDocumentStatus | undefined;
   stage: string | undefined;
+  completedStages: string[];
   chunks: { total: number; processed: number } | undefined;
   awaitingProcessing: boolean;
 } {
@@ -29,6 +38,7 @@ export function useDocumentPolling(
     PolledDocumentStatus | undefined
   >(undefined);
   const [stage, setStage] = useState<string | undefined>(undefined);
+  const [completedStages, setCompletedStages] = useState<string[]>([]);
   const [chunks, setChunks] = useState<
     { total: number; processed: number } | undefined
   >(undefined);
@@ -48,6 +58,7 @@ export function useDocumentPolling(
       prevDocKeyRef.current = docKey;
       setPolledUiStatus(undefined);
       setStage(undefined);
+      setCompletedStages([]);
       setChunks(undefined);
       setAwaitingProcessing(false);
       setUseFallbackPolling(false);
@@ -83,6 +94,7 @@ export function useDocumentPolling(
               ? payload.stage
               : payload.status;
           setStage(rawStage);
+          setCompletedStages(stagesBefore(rawStage));
 
           const c = payload.chunks;
           if (
@@ -142,6 +154,7 @@ export function useDocumentPolling(
               ? payload.stage
               : payload.status;
           setStage(rawStage);
+          setCompletedStages(stagesBefore(rawStage));
 
           const c = payload.chunks;
           if (
@@ -190,6 +203,7 @@ export function useDocumentPolling(
   return {
     status: polledUiStatus,
     stage,
+    completedStages,
     chunks,
     awaitingProcessing: enabled && awaitingProcessing,
   };

--- a/frontend-demo/app/lib/hooks/useDocumentPolling.ts
+++ b/frontend-demo/app/lib/hooks/useDocumentPolling.ts
@@ -23,6 +23,38 @@ function stagesBefore(currentStage: string): string[] {
   return Array.from(PIPELINE_STAGES.slice(0, idx));
 }
 
+/**
+ * Resolve the display stage from a raw SSE/poll payload.
+ *
+ * - On failure: use error.stage (the pipeline step that failed) so the
+ *   pipeline list can highlight the correct row. Fall back to the last
+ *   known non-failure stage string.
+ * - "uploaded" is only emitted by the synchronous path and maps to "queued"
+ *   (the nearest PIPELINE_STAGES entry) to avoid an indexOf miss.
+ * - "failed" itself is not a pipeline step — handled via the `failed` flag.
+ */
+function resolveDisplayStage(payload: {
+  status: string;
+  stage?: string;
+  error?: { stage?: string } | null;
+}): string {
+  if (payload.status === "failed") {
+    const errorStage = payload.error?.stage;
+    if (errorStage && errorStage !== "failed" && PIPELINE_STAGES.indexOf(errorStage as never) >= 0) {
+      return errorStage;
+    }
+    // fall back to the last stage field the server sent, or a safe default
+    return payload.stage ?? "extracting";
+  }
+  if (payload.status === "uploaded" || payload.stage === "uploaded") {
+    return "queued";
+  }
+  if (typeof payload.stage === "string" && payload.stage.length > 0) {
+    return payload.stage;
+  }
+  return payload.status;
+}
+
 export function useDocumentPolling(
   documentId: string | undefined,
   statusEndpoint: string | undefined,
@@ -89,10 +121,7 @@ export function useDocumentPolling(
         try {
           const payload = JSON.parse(event.data);
 
-          const rawStage =
-            typeof payload.stage === "string" && payload.stage.length > 0
-              ? payload.stage
-              : payload.status;
+          const rawStage = resolveDisplayStage(payload);
           setStage(rawStage);
           setCompletedStages(stagesBefore(rawStage));
 
@@ -149,10 +178,7 @@ export function useDocumentPolling(
 
           setAwaitingProcessing(false);
 
-          const rawStage =
-            typeof payload.stage === "string" && payload.stage.length > 0
-              ? payload.stage
-              : payload.status;
+          const rawStage = resolveDisplayStage(payload);
           setStage(rawStage);
           setCompletedStages(stagesBefore(rawStage));
 

--- a/frontend-demo/app/lib/stageLabels.ts
+++ b/frontend-demo/app/lib/stageLabels.ts
@@ -1,10 +1,36 @@
 export const STAGE_LABELS: Record<string, string> = {
-  queued: "Queued…",
-  uploaded: "Uploaded…",
-  extracting: "Extracting text…",
-  chunking: "Chunking…",
-  embedding: "Embedding…",
-  storing: "Storing…",
+  queued: "Queued",
+  uploaded: "Uploaded",
+  extracting: "Extracting text",
+  chunking: "Chunking",
+  embedding: "Embedding",
+  storing: "Storing",
   completed: "Ready",
   failed: "Failed",
+};
+
+/**
+ * Ordered list of pipeline stages as they progress on the backend.
+ * "uploading" is a synthetic client-side stage prepended before server stages begin.
+ */
+export const PIPELINE_STAGES = [
+  "uploading",
+  "queued",
+  "extracting",
+  "chunking",
+  "embedding",
+  "storing",
+  "completed",
+] as const;
+
+export type PipelineStage = (typeof PIPELINE_STAGES)[number];
+
+export const PIPELINE_STAGE_LABELS: Record<PipelineStage, string> = {
+  uploading: "Uploading",
+  queued: "Queued",
+  extracting: "Extracting text",
+  chunking: "Chunking",
+  embedding: "Embedding",
+  storing: "Storing",
+  completed: "Ready",
 };


### PR DESCRIPTION
## Summary

Replaces the single-line upload/processing status with a persistent pipeline-style progress list in the upload modal, driven by existing SSE (and polling fallback) document status updates.

## Requirements addressed

| Requirement | Status |
|---|---|
| Replace single changing status text with a persistent stage list | ✅ `IngestionPipeline` renders all stages simultaneously at all times |
| Display all ingestion stages at once (completed, current, upcoming) | ✅ `PIPELINE_STAGES.map` renders the full list every render |
| Distinct visual states: pending / in progress / completed / failed | ✅ `StageRow` + `getStageState` drive four distinct styles |
| Lightweight indicators (checkmarks, spinner, muted pending dots, connectors) | ✅ Lucide icons + connector lines between rows |
| Stable under rapid SSE updates — no flickering or teleporting | ✅ `useAnimatedStage` steps through skipped indices at `STEP_MS` intervals |
| Correct behavior for both successful and failed ingestions | ✅ Success completes the list to "Ready"; failure resolves `error.stage` from the backend payload to highlight the exact row that failed |

## Added features

Beyond the core requirements, the following UX improvements were included to make the upload flow feel complete and polished:

- **Two-column modal layout** — Pipeline list on the left; a right panel shows the file name + spinner during processing, then a large green checkmark and "Upload Successful" once the list visually reaches Ready. Eliminates the empty whitespace that would have been left by the pipeline list alone.
- **Animated emerald border sweep** — A thick green border sweeps around the modal over 1.5 s on success, giving the user a satisfying visual signal before auto-close. Both the border and the close timer start from the same `pipelineVisuallyComplete` event so they stay perfectly in sync.
- **"Dismiss and wait" button** — Appears inline with the "Upload document" heading while processing is in flight; hides only after the pipeline animation visually completes (not on the raw SSE event), preventing premature disappearance.
- **Embedding chunk hint** — Chunk count shown under the Embedding row using absolute positioning so it never causes layout shift.
- **429 / API error copy** — Rate-limit responses surface a specific message ("Too many requests — wait a moment…") rather than the generic "Upload failed." Backend `detail` strings are also forwarded to the user.
- **Upload button disabled when doc is attached** — Paperclip icon is disabled with a tooltip when a document is already active, preventing a confusing re-upload flow.
- **Incremental animation for fast backends** — When the backend skips several stages in one SSE burst, `useAnimatedStage` ticks through each intermediate step so progress always feels sequential.

## Testing

Frontend-demo follows a lighter testing posture than the backend — automated test coverage for UI components is not a priority for frontend issues. The critical paths (failure highlighting, `uploaded` → `queued` mapping, removed dead prop, comment accuracy) were verified via manual testing and a structured code review pass. The `resolveDisplayStage` logic and `useAnimatedStage` stepping are the main units that would benefit from future test coverage if that bar is raised.

## How to test manually

1. Upload a document — confirm pipeline steps animate sequentially, chunk count appears under Embedding without layout shift, right panel switches to checkmark in sync with the list reaching Ready, border sweeps for 1.5 s, modal closes.
2. Trigger a 429 (or other API error) — confirm user-facing message is specific, not generic.
3. With a document attached, confirm the paperclip is disabled and shows the tooltip.
4. Simulate a server-side failure — confirm the pipeline highlights the failed row rather than collapsing all rows to pending.