### PR TITLE
Implement hybrid retrieval (vector + PostgreSQL full-text search)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ yarn-error.log*
 .next/
 out/
 
+# Local agent docs and tooling (not pushed to remote)
+.cursor/
+docs/
+
 # IDE
 .vscode/
 .idea/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -320,6 +320,21 @@ docker compose down -v
 docker compose up --build
 ```
 
+### Hybrid retrieval (`content_tsv`)
+
+To enable vector + PostgreSQL full-text hybrid search (issue P3B-1), apply the migration
+and set `HYBRID_RETRIEVAL_ENABLED=true` in `backend/.env`:
+
+```bash
+docker compose exec db psql -U postgres -d postgres \
+    -f /docker-entrypoint-initdb.d/004_hybrid_retrieval.sql
+```
+
+Or paste the contents of `backend/db/init/004_hybrid_retrieval.sql` into `psql`.
+The column `content_tsv` is a generated `tsvector` from `chunk_text`; existing chunks
+are backfilled automatically. Hybrid retrieval requires the SQLAlchemy/PostgreSQL
+backend (`APP_ENV=development` or `APP_ENV=test` with `DATABASE_URL`).
+
 ### Ports
 
 - **8000** — HTTP API. Expose behind a reverse proxy or load balancer.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -84,6 +84,7 @@ ENABLE_STREAMING=false
 # QUEUE_RETRY_BASE_DELAY=2.0          # base seconds for exponential backoff between retries
 
 # ── Retrieval & chat limits ────────────────────────────────────────────────
+# HYBRID_RETRIEVAL_ENABLED=false      # fuse pgvector + PostgreSQL full-text (SQLAlchemy only)
 # RETRIEVAL_MAX_CONCURRENCY=8         # max concurrent vector searches (chat retrieval)
 # SQLALCHEMY_RETRIEVAL_CONCURRENCY=8  # max concurrent DB sessions for pgvector search
 # CHAT_BATCH_MAX_ITEMS=20             # max queries per POST /chat/batch

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -110,6 +110,9 @@ class Settings:
     ).lower() in ("1", "true", "yes")
     QUERY_TRANSFORMATION_STRATEGY: str = _get_query_transformation_strategy()
     RETRIEVAL_MAX_CONCURRENCY: int = max(1, int(os.getenv("RETRIEVAL_MAX_CONCURRENCY", "8")))
+    HYBRID_RETRIEVAL_ENABLED: bool = os.getenv(
+        "HYBRID_RETRIEVAL_ENABLED", "false"
+    ).lower() in ("1", "true", "yes")
     SUPABASE_IO_CONCURRENCY: int = max(1, int(os.getenv("SUPABASE_IO_CONCURRENCY", "16")))
     CHAT_BATCH_MAX_ITEMS: int = max(1, int(os.getenv("CHAT_BATCH_MAX_ITEMS", "20")))
     CHAT_MAX_DOC_IDS_PER_QUERY: int = max(1, int(os.getenv("CHAT_MAX_DOC_IDS_PER_QUERY", "10")))

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3,8 +3,8 @@ from datetime import datetime
 import uuid
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import Column, Computed, DateTime, ForeignKey, Integer, String
-from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import declarative_base
 
 from core.config import get_embedding_dim
@@ -30,13 +30,6 @@ class DocumentChunk(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     document_id = Column(UUID(as_uuid=True), ForeignKey("documents.id"), nullable=False)
     chunk_text = Column(String, nullable=False)
-    content_tsv = Column(
-        TSVECTOR,
-        Computed(
-            "to_tsvector('english', coalesce(chunk_text, ''))",
-            persisted=True,
-        ),
-    )
     embedding = Column(Vector(get_embedding_dim()), nullable=False)
     chunk_index = Column(Integer, nullable=False, default=0)
     page_number = Column(Integer, nullable=True)

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3,8 +3,8 @@ from datetime import datetime
 import uuid
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy import Column, Computed, DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import declarative_base
 
 from core.config import get_embedding_dim
@@ -30,6 +30,13 @@ class DocumentChunk(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     document_id = Column(UUID(as_uuid=True), ForeignKey("documents.id"), nullable=False)
     chunk_text = Column(String, nullable=False)
+    content_tsv = Column(
+        TSVECTOR,
+        Computed(
+            "to_tsvector('english', coalesce(chunk_text, ''))",
+            persisted=True,
+        ),
+    )
     embedding = Column(Vector(get_embedding_dim()), nullable=False)
     chunk_index = Column(Integer, nullable=False, default=0)
     page_number = Column(Integer, nullable=True)

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -181,13 +181,18 @@ async def find_similar_chunks(
     query_embedding: list[float],
     match_count: int = 5,
     session_id: str | None = None,
+    query_text: str | None = None,
 ) -> list[ChunkMatch]:
     """Find similar chunks with retry logic."""
     service = get_db_service()
 
     async def _search():
         return await service.find_similar_chunks(
-            doc_id, query_embedding, match_count, session_id=session_id
+            doc_id,
+            query_embedding,
+            match_count,
+            session_id=session_id,
+            query_text=query_text,
         )
 
     return await retry_async(

--- a/backend/db/base.py
+++ b/backend/db/base.py
@@ -65,8 +65,9 @@ class DatabaseService(ABC):
         query_embedding: list[float],
         match_count: int = 5,
         session_id: Optional[str] = None,
+        query_text: Optional[str] = None,
     ) -> list[ChunkMatch]:
-        """Run vector similarity search for chunks."""
+        """Run vector similarity search for chunks (optionally hybrid with keyword search)."""
         pass
 
     @abstractmethod

--- a/backend/db/init/004_hybrid_retrieval.sql
+++ b/backend/db/init/004_hybrid_retrieval.sql
@@ -1,0 +1,7 @@
+-- Hybrid retrieval: PostgreSQL full-text search on chunk text
+ALTER TABLE document_chunks
+  ADD COLUMN IF NOT EXISTS content_tsv tsvector
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(chunk_text, ''))) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_document_chunks_content_tsv
+  ON document_chunks USING GIN (content_tsv);

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -316,17 +316,9 @@ class SQLAlchemyService(DatabaseService):
             async with self._retrieval_semaphore:
                 async with self.async_session() as session:
                     if not use_hybrid:
-                        result = await session.execute(
-                            select(DocumentChunk, Document.file_name)
-                            .join(Document, DocumentChunk.document_id == Document.id)
-                            .where(DocumentChunk.document_id == doc_id)
-                            .order_by(DocumentChunk.embedding.op("<=>")(query_embedding))
-                            .limit(match_count)
+                        matches = await self._find_vector_chunks(
+                            session, doc_id, query_embedding, match_count
                         )
-                        matches = [
-                            self._chunk_match_from_row(chunk, file_name)
-                            for chunk, file_name in result.all()
-                        ]
                     else:
                         vector_matches, keyword_matches = await asyncio.gather(
                             self._find_vector_chunks(

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -347,13 +347,11 @@ class SQLAlchemyService(DatabaseService):
                             session, doc_id, query_embedding, match_count
                         )
                     else:
-                        vector_matches, keyword_matches = await asyncio.gather(
-                            self._find_vector_chunks(
-                                session, doc_id, query_embedding, candidate_limit
-                            ),
-                            self._find_keyword_chunks(
-                                session, doc_id, query_text.strip(), candidate_limit
-                            ),
+                        vector_matches = await self._find_vector_chunks(
+                            session, doc_id, query_embedding, candidate_limit
+                        )
+                        keyword_matches = await self._find_keyword_chunks(
+                            session, doc_id, query_text.strip(), candidate_limit
                         )
                         matches_by_id: dict[str, ChunkMatch] = {}
                         for match in vector_matches + keyword_matches:

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from sqlalchemy import delete, func, literal_column, select, update as sql_update
 from sqlalchemy.dialects.postgresql import TSVECTOR
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -17,6 +18,20 @@ from db.base import ChunkMatch, ChunkRecord, DatabaseService
 from services.retrieval_service import merge_chunk_matches, reciprocal_rank_fusion
 
 logger = logging.getLogger(__name__)
+
+# Full-text config matches migration 004 (to_tsvector / plainto_tsquery).
+_FTS_LANGUAGE = "english"
+
+
+def _is_missing_content_tsv_error(exc: BaseException) -> bool:
+    """True when hybrid migration 004 has not been applied."""
+    message = str(exc).lower()
+    if "content_tsv" in message and "does not exist" in message:
+        return True
+    orig = getattr(exc, "__cause__", None) or getattr(exc, "orig", None)
+    if orig is not None and orig is not exc:
+        return _is_missing_content_tsv_error(orig)
+    return False
 
 
 class SQLAlchemyService(DatabaseService):
@@ -280,16 +295,25 @@ class SQLAlchemyService(DatabaseService):
     ) -> list[ChunkMatch]:
         """Full-text search on document_chunks.content_tsv (requires migration 004)."""
         content_tsv = literal_column("document_chunks.content_tsv", type_=TSVECTOR())
-        ts_query = func.plainto_tsquery("english", query_text)
+        ts_query = func.plainto_tsquery(_FTS_LANGUAGE, query_text)
         rank = func.ts_rank(content_tsv, ts_query).label("keyword_rank")
-        result = await session.execute(
-            select(DocumentChunk, Document.file_name, rank)
-            .join(Document, DocumentChunk.document_id == Document.id)
-            .where(DocumentChunk.document_id == doc_id)
-            .where(content_tsv.op("@@")(ts_query))
-            .order_by(rank.desc())
-            .limit(limit)
-        )
+        try:
+            result = await session.execute(
+                select(DocumentChunk, Document.file_name, rank)
+                .join(Document, DocumentChunk.document_id == Document.id)
+                .where(DocumentChunk.document_id == doc_id)
+                .where(content_tsv.op("@@")(ts_query))
+                .order_by(rank.desc())
+                .limit(limit)
+            )
+        except ProgrammingError as exc:
+            if _is_missing_content_tsv_error(exc):
+                logger.warning(
+                    "content_tsv column missing; apply backend/db/init/004_hybrid_retrieval.sql. "
+                    "Using vector-only results for this request."
+                )
+                return []
+            raise
         rows = result.all()
         return [
             self._chunk_match_from_row(chunk, file_name)
@@ -313,7 +337,7 @@ class SQLAlchemyService(DatabaseService):
             and query_text
             and query_text.strip()
         )
-        candidate_limit = max(match_count, match_count * 2)
+        candidate_limit = match_count * 2
 
         try:
             async with self._retrieval_semaphore:

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -6,7 +6,8 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import delete, func, select, text, update as sql_update
+from sqlalchemy import delete, func, literal_column, select, update as sql_update
+from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -278,21 +279,16 @@ class SQLAlchemyService(DatabaseService):
         limit: int,
     ) -> list[ChunkMatch]:
         """Full-text search on document_chunks.content_tsv (requires migration 004)."""
-        rank = text(
-            "ts_rank(document_chunks.content_tsv, plainto_tsquery('english', :query_text))"
-        ).label("keyword_rank")
+        content_tsv = literal_column("document_chunks.content_tsv", type_=TSVECTOR())
+        ts_query = func.plainto_tsquery("english", query_text)
+        rank = func.ts_rank(content_tsv, ts_query).label("keyword_rank")
         result = await session.execute(
             select(DocumentChunk, Document.file_name, rank)
             .join(Document, DocumentChunk.document_id == Document.id)
             .where(DocumentChunk.document_id == doc_id)
-            .where(
-                text(
-                    "document_chunks.content_tsv @@ plainto_tsquery('english', :query_text)"
-                )
-            )
+            .where(content_tsv.op("@@")(ts_query))
             .order_by(rank.desc())
-            .limit(limit),
-            {"query_text": query_text},
+            .limit(limit)
         )
         rows = result.all()
         return [

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -6,13 +6,14 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import delete, select, update as sql_update
+from sqlalchemy import delete, func, select, update as sql_update
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.models import Document, DocumentChunk
 from core.config import config
 from db.base import ChunkMatch, ChunkRecord, DatabaseService
+from services.retrieval_service import merge_chunk_matches, reciprocal_rank_fusion
 
 logger = logging.getLogger(__name__)
 
@@ -233,48 +234,126 @@ class SQLAlchemyService(DatabaseService):
             logger.info(f"[PostgreSQL] Marked {len(doc_ids)} stale document(s) as failed on startup")
             return doc_ids
 
+    def _chunk_match_from_row(
+        self, chunk: DocumentChunk, file_name: str, *, similarity: float | None = None
+    ) -> ChunkMatch:
+        return ChunkMatch(
+            id=str(chunk.id),
+            chunk_text=chunk.chunk_text,
+            document_id=str(chunk.document_id),
+            embedding=chunk.embedding,
+            created_at=str(chunk.created_at) if chunk.created_at else None,
+            similarity=similarity,
+            chunk_index=chunk.chunk_index,
+            page_number=chunk.page_number,
+            character_offset_start=chunk.character_offset_start,
+            character_offset_end=chunk.character_offset_end,
+            file_name=file_name,
+        )
+
+    async def _find_vector_chunks(
+        self,
+        session: AsyncSession,
+        doc_id: str,
+        query_embedding: list[float],
+        limit: int,
+    ) -> list[ChunkMatch]:
+        result = await session.execute(
+            select(DocumentChunk, Document.file_name)
+            .join(Document, DocumentChunk.document_id == Document.id)
+            .where(DocumentChunk.document_id == doc_id)
+            .order_by(DocumentChunk.embedding.op("<=>")(query_embedding))
+            .limit(limit)
+        )
+        return [
+            self._chunk_match_from_row(chunk, file_name)
+            for chunk, file_name in result.all()
+        ]
+
+    async def _find_keyword_chunks(
+        self,
+        session: AsyncSession,
+        doc_id: str,
+        query_text: str,
+        limit: int,
+    ) -> list[ChunkMatch]:
+        ts_query = func.plainto_tsquery("english", query_text)
+        rank = func.ts_rank(DocumentChunk.content_tsv, ts_query).label("keyword_rank")
+        result = await session.execute(
+            select(DocumentChunk, Document.file_name, rank)
+            .join(Document, DocumentChunk.document_id == Document.id)
+            .where(DocumentChunk.document_id == doc_id)
+            .where(DocumentChunk.content_tsv.op("@@")(ts_query))
+            .order_by(rank.desc())
+            .limit(limit)
+        )
+        rows = result.all()
+        return [
+            self._chunk_match_from_row(chunk, file_name)
+            for chunk, file_name, _rank in rows
+        ]
+
     async def find_similar_chunks(
         self,
         doc_id: str,
         query_embedding: list[float],
         match_count: int = 5,
         session_id: Optional[str] = None,
+        query_text: Optional[str] = None,
     ) -> list[ChunkMatch]:
         # TODO(Phase 3): use session_id for context filtering once implemented
-        """Find similar chunks using pgvector."""
-        # TODO(Phase 3): use session_id for context filtering once implemented
+        """Find chunks via vector search; optionally fuse with PostgreSQL full-text search."""
+        del session_id  # reserved for Phase 3 session-scoped retrieval
         start = time.perf_counter()
+        use_hybrid = (
+            config.HYBRID_RETRIEVAL_ENABLED
+            and query_text
+            and query_text.strip()
+        )
+        candidate_limit = max(match_count, match_count * 2)
+
         try:
             async with self._retrieval_semaphore:
                 async with self.async_session() as session:
-                    result = await session.execute(
-                        select(DocumentChunk, Document.file_name)
-                        .join(Document, DocumentChunk.document_id == Document.id)
-                        .where(DocumentChunk.document_id == doc_id)
-                        .order_by(DocumentChunk.embedding.op("<=>")(query_embedding))
-                        .limit(match_count)
-                    )
-                    rows = result.all()
-
-                    matches = [
-                        ChunkMatch(
-                            id=str(chunk.id),
-                            chunk_text=chunk.chunk_text,
-                            document_id=str(chunk.document_id),
-                            embedding=chunk.embedding,
-                            created_at=str(chunk.created_at) if chunk.created_at else None,
-                            chunk_index=chunk.chunk_index,
-                            page_number=chunk.page_number,
-                            character_offset_start=chunk.character_offset_start,
-                            character_offset_end=chunk.character_offset_end,
-                            file_name=file_name,
+                    if not use_hybrid:
+                        result = await session.execute(
+                            select(DocumentChunk, Document.file_name)
+                            .join(Document, DocumentChunk.document_id == Document.id)
+                            .where(DocumentChunk.document_id == doc_id)
+                            .order_by(DocumentChunk.embedding.op("<=>")(query_embedding))
+                            .limit(match_count)
                         )
-                        for chunk, file_name in rows
-                    ]
+                        matches = [
+                            self._chunk_match_from_row(chunk, file_name)
+                            for chunk, file_name in result.all()
+                        ]
+                    else:
+                        vector_matches, keyword_matches = await asyncio.gather(
+                            self._find_vector_chunks(
+                                session, doc_id, query_embedding, candidate_limit
+                            ),
+                            self._find_keyword_chunks(
+                                session, doc_id, query_text.strip(), candidate_limit
+                            ),
+                        )
+                        matches_by_id: dict[str, ChunkMatch] = {}
+                        for match in vector_matches + keyword_matches:
+                            matches_by_id[match.id] = match
+
+                        fused_ids = reciprocal_rank_fusion(
+                            [
+                                [m.id for m in vector_matches],
+                                [m.id for m in keyword_matches],
+                            ],
+                            limit=match_count,
+                        )
+                        matches = merge_chunk_matches(fused_ids, matches_by_id)
 
                     duration_ms = int((time.perf_counter() - start) * 1000)
+                    mode = "hybrid" if use_hybrid else "vector"
                     logger.debug(
-                        "[PostgreSQL] Vector search returned %s chunks for doc_id=%s in %sms",
+                        "[PostgreSQL] %s search returned %s chunks for doc_id=%s in %sms",
+                        mode,
                         len(matches),
                         doc_id,
                         duration_ms,
@@ -283,7 +362,7 @@ class SQLAlchemyService(DatabaseService):
         except Exception:
             duration_ms = int((time.perf_counter() - start) * 1000)
             logger.exception(
-                "[PostgreSQL] Vector search failed for doc_id=%s in %sms",
+                "[PostgreSQL] Chunk search failed for doc_id=%s in %sms",
                 doc_id,
                 duration_ms,
             )

--- a/backend/db/sqlalchemy_service.py
+++ b/backend/db/sqlalchemy_service.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import delete, func, select, update as sql_update
+from sqlalchemy import delete, func, select, text, update as sql_update
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -277,15 +277,22 @@ class SQLAlchemyService(DatabaseService):
         query_text: str,
         limit: int,
     ) -> list[ChunkMatch]:
-        ts_query = func.plainto_tsquery("english", query_text)
-        rank = func.ts_rank(DocumentChunk.content_tsv, ts_query).label("keyword_rank")
+        """Full-text search on document_chunks.content_tsv (requires migration 004)."""
+        rank = text(
+            "ts_rank(document_chunks.content_tsv, plainto_tsquery('english', :query_text))"
+        ).label("keyword_rank")
         result = await session.execute(
             select(DocumentChunk, Document.file_name, rank)
             .join(Document, DocumentChunk.document_id == Document.id)
             .where(DocumentChunk.document_id == doc_id)
-            .where(DocumentChunk.content_tsv.op("@@")(ts_query))
+            .where(
+                text(
+                    "document_chunks.content_tsv @@ plainto_tsquery('english', :query_text)"
+                )
+            )
             .order_by(rank.desc())
-            .limit(limit)
+            .limit(limit),
+            {"query_text": query_text},
         )
         rows = result.all()
         return [

--- a/backend/db/supabase_service.py
+++ b/backend/db/supabase_service.py
@@ -231,7 +231,9 @@ class SupabaseService(DatabaseService):
         query_embedding: list[float],
         match_count: int = 5,
         session_id: Optional[str] = None,
+        query_text: Optional[str] = None,
     ) -> list[ChunkMatch]:
+        del query_text  # hybrid retrieval is SQLAlchemy/PostgreSQL only
         # TODO(Phase 3): use session_id for context filtering once implemented
         """Find similar chunks using Supabase RPC."""
         # TODO(Phase 3): use session_id for context filtering once implemented

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -127,6 +127,7 @@ async def _retrieve_chunks_for_documents(
     query_embedding: list[float],
     match_count: int,
     session_id: Optional[str] = None,
+    query_text: Optional[str] = None,
 ) -> list:
     retrieval_semaphore = _get_retrieval_semaphore()
 
@@ -137,6 +138,7 @@ async def _retrieve_chunks_for_documents(
                 query_embedding=query_embedding,
                 match_count=match_count,
                 session_id=session_id,
+                query_text=query_text,
             )
 
     per_document_chunks = await asyncio.gather(
@@ -186,6 +188,7 @@ async def answer_question_for_document(
             query_embedding=query_embedding,
             match_count=match_count,
             session_id=session_id,
+            query_text=question,
         )
         for chunk in chunks:
             key = (chunk.document_id, chunk.chunk_index)
@@ -265,6 +268,7 @@ async def answer_question_stream_for_document(
                 doc_ids=[doc_id],
                 query_embedding=query_embedding,
                 match_count=match_count,
+                query_text=question,
             )
             for chunk in chunks:
                 key = (chunk.document_id, chunk.chunk_index)
@@ -406,6 +410,7 @@ async def answer_questions_for_documents_batch(
                     query_embedding=query_embedding,
                     match_count=query["match_count"],
                     session_id=session_id,
+                    query_text=query["question"],
                 )
                 for chunk in chunks:
                     key = (chunk.document_id, chunk.chunk_index)

--- a/backend/services/retrieval_service.py
+++ b/backend/services/retrieval_service.py
@@ -1,0 +1,48 @@
+"""
+Hybrid retrieval helpers: Reciprocal Rank Fusion (RRF) and result merging.
+"""
+
+from __future__ import annotations
+
+from db.base import ChunkMatch
+
+# Standard RRF constant (Cormack et al.)
+RRF_K_DEFAULT = 60
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: list[list[str]],
+    *,
+    k: int = RRF_K_DEFAULT,
+    limit: int | None = None,
+) -> list[str]:
+    """
+    Merge multiple ranked lists of chunk IDs using Reciprocal Rank Fusion.
+
+    score(d) = sum over each list L: 1 / (k + rank_L(d))
+    """
+    if not ranked_lists:
+        return []
+
+    scores: dict[str, float] = {}
+    for ranked in ranked_lists:
+        for rank, item_id in enumerate(ranked, start=1):
+            scores[item_id] = scores.get(item_id, 0.0) + 1.0 / (k + rank)
+
+    ordered = sorted(scores.keys(), key=lambda item_id: scores[item_id], reverse=True)
+    if limit is not None:
+        return ordered[:limit]
+    return ordered
+
+
+def merge_chunk_matches(
+    ranked_ids: list[str],
+    matches_by_id: dict[str, ChunkMatch],
+) -> list[ChunkMatch]:
+    """Return ChunkMatch objects in fused rank order, skipping unknown IDs."""
+    merged: list[ChunkMatch] = []
+    for chunk_id in ranked_ids:
+        match = matches_by_id.get(chunk_id)
+        if match is not None:
+            merged.append(match)
+    return merged

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -81,6 +81,7 @@ async def test_answer_question_for_document_orchestrates_flow():
         query_embedding=[0.1, 0.2],
         match_count=7,
         session_id=None,
+        query_text="What is this about?",
     )
     mock_context.assert_called_once_with(chunks, session_context=None)
     mock_answer.assert_awaited_once_with("What is this about?", "combined context")
@@ -113,6 +114,7 @@ async def test_answer_question_for_document_passes_session_id():
         query_embedding=[0.1, 0.2],
         match_count=7,
         session_id="session-abc",
+        query_text="Q",
     )
     mock_history.assert_awaited_once()
 

--- a/backend/tests/test_hybrid_retrieval.py
+++ b/backend/tests/test_hybrid_retrieval.py
@@ -16,8 +16,7 @@ def test_reciprocal_rank_fusion_prefers_items_in_both_lists():
     vector_ranked = ["a", "b", "c"]
     keyword_ranked = ["b", "d", "e"]
     fused = reciprocal_rank_fusion([vector_ranked, keyword_ranked], limit=3)
-    assert fused[0] == "b"
-    assert set(fused) == {"b", "a", "d"} or set(fused) == {"b", "d", "a"}
+    assert fused == ["b", "a", "d"]
 
 
 def test_reciprocal_rank_fusion_respects_limit():
@@ -101,6 +100,61 @@ async def test_find_similar_chunks_hybrid_invokes_both_paths():
     service._find_vector_chunks.assert_called_once()
     service._find_keyword_chunks.assert_called_once()
     assert {m.id for m in results} == {"vec-1", "key-1"}
+
+
+@pytest.mark.asyncio
+async def test_find_similar_chunks_hybrid_fusion_order():
+    pytest.importorskip("pgvector")
+    from db.sqlalchemy_service import SQLAlchemyService
+
+    service = SQLAlchemyService()
+    service._retrieval_semaphore = __import__("asyncio").Semaphore(10)
+
+    shared = ChunkMatch(id="shared", chunk_text="both lists")
+    vec_only = ChunkMatch(id="vec-only", chunk_text="vector")
+    key_only = ChunkMatch(id="key-only", chunk_text="keyword")
+    service._find_vector_chunks = AsyncMock(return_value=[shared, vec_only])
+    service._find_keyword_chunks = AsyncMock(return_value=[shared, key_only])
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    service.async_session = lambda: _FakeSession()
+
+    with patch.object(config, "HYBRID_RETRIEVAL_ENABLED", True):
+        results = await service.find_similar_chunks(
+            "doc-1",
+            [0.1, 0.2],
+            match_count=3,
+            query_text="lookup",
+        )
+
+    assert [m.id for m in results] == ["shared", "vec-only", "key-only"]
+
+
+@pytest.mark.asyncio
+async def test_find_keyword_chunks_returns_empty_when_column_missing():
+    pytest.importorskip("pgvector")
+    from sqlalchemy.exc import ProgrammingError
+
+    from db.sqlalchemy_service import SQLAlchemyService
+
+    service = SQLAlchemyService()
+
+    class _FakeSession:
+        async def execute(self, *args, **kwargs):
+            raise ProgrammingError(
+                "stmt",
+                {},
+                Exception('column "content_tsv" does not exist'),
+            )
+
+    results = await service._find_keyword_chunks(_FakeSession(), "doc-1", "keyword", 5)
+    assert results == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_hybrid_retrieval.py
+++ b/backend/tests/test_hybrid_retrieval.py
@@ -1,0 +1,165 @@
+"""Tests for hybrid retrieval (RRF, config toggle, PostgreSQL full-text)."""
+
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.config import config
+from db.base import ChunkMatch
+from services.retrieval_service import merge_chunk_matches, reciprocal_rank_fusion
+
+
+def test_reciprocal_rank_fusion_prefers_items_in_both_lists():
+    vector_ranked = ["a", "b", "c"]
+    keyword_ranked = ["b", "d", "e"]
+    fused = reciprocal_rank_fusion([vector_ranked, keyword_ranked], limit=3)
+    assert fused[0] == "b"
+    assert set(fused) == {"b", "a", "d"} or set(fused) == {"b", "d", "a"}
+
+
+def test_reciprocal_rank_fusion_respects_limit():
+    fused = reciprocal_rank_fusion([["x", "y", "z"]], limit=2)
+    assert fused == ["x", "y"]
+
+
+def test_merge_chunk_matches_preserves_fused_order():
+    matches = {
+        "1": ChunkMatch(id="1", chunk_text="one"),
+        "2": ChunkMatch(id="2", chunk_text="two"),
+    }
+    merged = merge_chunk_matches(["2", "1"], matches)
+    assert [m.id for m in merged] == ["2", "1"]
+
+
+@pytest.mark.asyncio
+async def test_find_similar_chunks_vector_only_when_hybrid_disabled():
+    pytest.importorskip("pgvector")
+    from db.sqlalchemy_service import SQLAlchemyService
+
+    service = SQLAlchemyService()
+    service._retrieval_semaphore = __import__("asyncio").Semaphore(10)
+    service._find_keyword_chunks = AsyncMock(return_value=[])
+
+    vector_match = ChunkMatch(id="vec-1", chunk_text="vector chunk")
+    service._find_vector_chunks = AsyncMock(return_value=[vector_match])
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    service.async_session = lambda: _FakeSession()
+
+    with patch.object(config, "HYBRID_RETRIEVAL_ENABLED", False):
+        results = await service.find_similar_chunks(
+            "doc-1",
+            [0.1, 0.2],
+            match_count=5,
+            query_text="exact keyword",
+        )
+
+    assert results == [vector_match]
+    service._find_keyword_chunks.assert_not_called()
+    service._find_vector_chunks.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_find_similar_chunks_hybrid_invokes_both_paths():
+    pytest.importorskip("pgvector")
+    from db.sqlalchemy_service import SQLAlchemyService
+
+    service = SQLAlchemyService()
+    service._retrieval_semaphore = __import__("asyncio").Semaphore(10)
+
+    vector_match = ChunkMatch(id="vec-1", chunk_text="alpha")
+    keyword_match = ChunkMatch(id="key-1", chunk_text="beta")
+    service._find_vector_chunks = AsyncMock(return_value=[vector_match])
+    service._find_keyword_chunks = AsyncMock(return_value=[keyword_match])
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    service.async_session = lambda: _FakeSession()
+
+    with patch.object(config, "HYBRID_RETRIEVAL_ENABLED", True):
+        results = await service.find_similar_chunks(
+            "doc-1",
+            [0.1, 0.2],
+            match_count=5,
+            query_text="beta",
+        )
+
+    service._find_vector_chunks.assert_called_once()
+    service._find_keyword_chunks.assert_called_once()
+    assert {m.id for m in results} == {"vec-1", "key-1"}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_keyword_finds_exact_term_integration():
+    """Keyword path retrieves chunks containing an exact rare token."""
+    if sys.platform == "win32":
+        pytest.skip("Psycopg async mode not supported with ProactorEventLoop on Windows")
+
+    pytest.importorskip("pgvector")
+    from sqlalchemy import text
+
+    from core.config import get_embedding_dim
+    from db.base import ChunkRecord
+    from db.sqlalchemy_service import SQLAlchemyService
+
+    db = SQLAlchemyService()
+    migration_path = (
+        Path(__file__).resolve().parents[1] / "db" / "init" / "004_hybrid_retrieval.sql"
+    )
+    migration_sql = migration_path.read_text(encoding="utf-8")
+    async with db.engine.begin() as conn:
+        for statement in migration_sql.split(";"):
+            stmt = statement.strip()
+            if stmt:
+                await conn.execute(text(stmt))
+
+    dim = get_embedding_dim()
+    filler = [0.0] * dim
+    filler[0] = 1.0
+    unique_token = f"HYBRID-EXACT-{uuid.uuid4().hex[:8]}"
+    file_name = f"hybrid_test_{uuid.uuid4()}.pdf"
+
+    doc_id = await db.create_document(file_name)
+    await db.store_chunks_with_embeddings(
+        doc_id,
+        [
+            ChunkRecord(
+                chunk_text=f"Intro paragraph without special terms.",
+                embedding=filler,
+                chunk_index=0,
+                character_offset_start=0,
+                character_offset_end=40,
+            ),
+            ChunkRecord(
+                chunk_text=f"Section referencing {unique_token} for lookup.",
+                embedding=filler,
+                chunk_index=1,
+                character_offset_start=41,
+                character_offset_end=80,
+            ),
+        ],
+    )
+
+    with patch.object(config, "HYBRID_RETRIEVAL_ENABLED", True):
+        matches = await db.find_similar_chunks(
+            doc_id,
+            filler,
+            match_count=5,
+            query_text=unique_token,
+        )
+
+    assert any(unique_token in (m.chunk_text or "") for m in matches)


### PR DESCRIPTION
## Summary
Closes #290

Adds optional hybrid chunk retrieval that combines pgvector similarity search with PostgreSQL full-text search, merged via Reciprocal Rank Fusion (RRF), improving recall for exact terms, identifiers, and rare keywords alongside semantic matches.

## Changes
- **Schema:** `004_hybrid_retrieval.sql` adds generated `content_tsv` column and GIN index on `document_chunks`
- **Retrieval:** New `retrieval_service.py` with RRF fusion and result-merging helpers
- **SQLAlchemy:** `find_similar_chunks` runs vector search; when `HYBRID_RETRIEVAL_ENABLED=true`, also runs keyword search and fuses results
- **Config:** `HYBRID_RETRIEVAL_ENABLED` (default `false`) for backward-compatible opt-in
- **Chat wiring:** Passes user question as `query_text` into retrieval from `chat_service`
- **Resilience:** If migration 004 is missing, keyword search logs a warning and falls back to vector-only instead of failing the request
- **Supabase:** Unchanged vector-only behavior (hybrid requires local PostgreSQL)
- **Tests:** RRF unit tests, config toggle, fusion ordering, keyword fallback, and integration test for exact-term retrieval
- **Docs:** `DEVELOPMENT.md` and `.env.example` updated with migration and config notes

## Out of scope additions
- **`.gitignore` entries for `.cursor/` and `docs/`** — Keeps local agent prompts and issue drafts off the remote. Independent of hybrid retrieval but prevents accidental commits; can be reverted without affecting retrieval.

## Testing
- Full suite: **285 passed**, 2 skipped (`make tests`)
- Unit tests: RRF ordering, hybrid on/off, fusion order through `find_similar_chunks`
- Integration: exact token retrieval via keyword path (with migration applied in test)
- Edge cases: missing `content_tsv` column → empty keyword results, vector-only fusion

## Migration steps
1. Apply migration on existing databases:
   ```bash
   docker compose exec db psql -U postgres -d postgres \
       -f /docker-entrypoint-initdb.d/004_hybrid_retrieval.sql
   ```
2. Set in `backend/.env`:
   ```
   HYBRID_RETRIEVAL_ENABLED=true
   ```
3. Fresh Docker volumes pick up `004` automatically from `backend/db/init/`

Hybrid retrieval only applies when using the SQLAlchemy/PostgreSQL backend (`APP_ENV=development` or `APP_ENV=test` with `DATABASE_URL`).

## Notes for reviewer
- `content_tsv` is a **DB-generated** column; it is intentionally not mapped on the SQLAlchemy ORM model to avoid insert/RETURNING issues on databases without the migration.
- Full-text search uses **English** only (`to_tsvector` / `plainto_tsquery`); language is not configurable yet.
- Default remains **vector-only** (`HYBRID_RETRIEVAL_ENABLED=false`), so existing deployments are unaffected until opt-in.