### PR TITLE
[P3B-2] Add retrieval reranking layer

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -82,6 +82,8 @@ ENABLE_STREAMING=false
 # QUEUE_RETRY_BASE_DELAY=2.0          # base seconds for exponential backoff between retries
 
 # ── Retrieval & chat limits ────────────────────────────────────────────────
+# ENABLE_RERANKING=false              # reorder retrieved chunks before context assembly
+# RERANKER_PROVIDER=similarity        # baseline deterministic reranker (when enabled)
 # RETRIEVAL_MAX_CONCURRENCY=8         # max concurrent vector searches (chat retrieval)
 # SQLALCHEMY_RETRIEVAL_CONCURRENCY=8  # max concurrent DB sessions for pgvector search
 # CHAT_BATCH_MAX_ITEMS=20             # max queries per POST /chat/batch

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -110,6 +110,12 @@ class Settings:
     ).lower() in ("1", "true", "yes")
     QUERY_TRANSFORMATION_STRATEGY: str = _get_query_transformation_strategy()
     RETRIEVAL_MAX_CONCURRENCY: int = max(1, int(os.getenv("RETRIEVAL_MAX_CONCURRENCY", "8")))
+    ENABLE_RERANKING: bool = os.getenv("ENABLE_RERANKING", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    RERANKER_PROVIDER: str = os.getenv("RERANKER_PROVIDER", "similarity").strip().lower()
     SUPABASE_IO_CONCURRENCY: int = max(1, int(os.getenv("SUPABASE_IO_CONCURRENCY", "16")))
     CHAT_BATCH_MAX_ITEMS: int = max(1, int(os.getenv("CHAT_BATCH_MAX_ITEMS", "20")))
     CHAT_MAX_DOC_IDS_PER_QUERY: int = max(1, int(os.getenv("CHAT_MAX_DOC_IDS_PER_QUERY", "10")))

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -9,6 +9,7 @@ from core.session import SessionContext
 from db import find_similar_chunks
 from services.context_service import build_context_from_chunks
 from services.query_service import transform_query
+from services.retrieval_service import rerank_chunks_if_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,11 @@ async def _retrieve_chunks_for_documents(
     return merged_chunks
 
 
+async def _finalize_retrieved_chunks(question: str, chunks: list, match_count: int) -> list:
+    """Apply optional reranking before context assembly."""
+    return await rerank_chunks_if_enabled(question, chunks, top_k=match_count)
+
+
 def _build_sources(chunks: list) -> list[dict]:
     """Extract citation metadata from retrieved chunks."""
     return [
@@ -192,7 +198,7 @@ async def answer_question_for_document(
             if key not in seen_chunk_keys:
                 seen_chunk_keys.add(key)
                 all_chunks.append(chunk)
-    matching_chunks = all_chunks
+    matching_chunks = await _finalize_retrieved_chunks(question, all_chunks, match_count)
     context = build_context_from_chunks(matching_chunks, session_context=session_context)
     answer = await generate_answer(question, context)
 
@@ -249,7 +255,7 @@ async def answer_question_stream_for_document(
                 if key not in seen_chunk_keys:
                     seen_chunk_keys.add(key)
                     all_chunks.append(chunk)
-        matching_chunks = all_chunks
+        matching_chunks = await _finalize_retrieved_chunks(question, all_chunks, match_count)
         context = build_context_from_chunks(matching_chunks, session_context=session_context)
 
         async for chunk in generate_answer_stream(question, context):
@@ -365,7 +371,9 @@ async def answer_questions_for_documents_batch(
                     if key not in seen_chunk_keys:
                         seen_chunk_keys.add(key)
                         all_chunks.append(chunk)
-            matching_chunks = all_chunks
+            matching_chunks = await _finalize_retrieved_chunks(
+                query["question"], all_chunks, query["match_count"]
+            )
             context = build_context_from_chunks(matching_chunks, session_context=session_context)
             answer = await generate_answer(query["question"], context)
 

--- a/backend/services/reranker/__init__.py
+++ b/backend/services/reranker/__init__.py
@@ -56,10 +56,13 @@ async def rerank_chunks_if_enabled(
     """
     Apply configured reranking after retrieval and before context construction.
 
-    When ENABLE_RERANKING is false, returns chunks unchanged.
+    When ENABLE_RERANKING is false, returns chunks unchanged (no top_k truncation).
     """
     if not chunks:
         return []
+
+    if not config.ENABLE_RERANKING:
+        return chunks
 
     provider = get_reranker_provider()
     request = RerankRequest(query=query, candidates=chunks, top_k=top_k)

--- a/backend/services/reranker/__init__.py
+++ b/backend/services/reranker/__init__.py
@@ -1,0 +1,82 @@
+"""Reranker provider factory."""
+
+from __future__ import annotations
+
+import logging
+
+from core.config import config
+from db.base import ChunkMatch
+from services.reranker.base import RerankRequest, RerankResult, RerankerProvider
+from services.reranker.noop import NoopRerankerProvider
+from services.reranker.similarity import SimilarityRerankerProvider
+
+logger = logging.getLogger(__name__)
+
+_reranker_provider: RerankerProvider | None = None
+
+VALID_RERANKER_PROVIDERS = {"similarity"}
+
+
+def _reset_reranker_provider() -> None:
+    """Clear cached provider (for tests)."""
+    global _reranker_provider
+    _reranker_provider = None
+
+
+def get_reranker_provider() -> RerankerProvider:
+    """Return singleton reranker based on configuration."""
+    global _reranker_provider
+
+    if _reranker_provider is not None:
+        return _reranker_provider
+
+    if not config.ENABLE_RERANKING:
+        _reranker_provider = NoopRerankerProvider()
+        return _reranker_provider
+
+    name = config.RERANKER_PROVIDER
+    if name == "similarity":
+        _reranker_provider = SimilarityRerankerProvider()
+        logger.info("Using similarity reranker provider")
+    else:
+        raise ValueError(
+            f"Unknown RERANKER_PROVIDER={name!r}. "
+            f"Expected one of: {', '.join(sorted(VALID_RERANKER_PROVIDERS))}."
+        )
+
+    return _reranker_provider
+
+
+async def rerank_chunks_if_enabled(
+    query: str,
+    chunks: list[ChunkMatch],
+    *,
+    top_k: int | None = None,
+) -> list[ChunkMatch]:
+    """
+    Apply configured reranking after retrieval and before context construction.
+
+    When ENABLE_RERANKING is false, returns chunks unchanged.
+    """
+    if not chunks:
+        return []
+
+    provider = get_reranker_provider()
+    request = RerankRequest(query=query, candidates=chunks, top_k=top_k)
+    result = await provider.rerank(request)
+
+    if config.ENABLE_RERANKING and result.original_order != result.reranked_order:
+        logger.debug(
+            "Reranked %d chunk(s): original=%s -> reranked=%s",
+            len(result.candidates),
+            result.original_order,
+            result.reranked_order,
+        )
+    elif config.ENABLE_RERANKING:
+        logger.debug(
+            "Reranking enabled; order unchanged for %d chunk(s): %s",
+            len(result.candidates),
+            result.reranked_order,
+        )
+
+    return result.candidates

--- a/backend/services/reranker/base.py
+++ b/backend/services/reranker/base.py
@@ -1,0 +1,34 @@
+"""Reranking provider abstraction and shared input/output types."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from db.base import ChunkMatch
+
+
+@dataclass(frozen=True)
+class RerankRequest:
+    """Standard reranking input."""
+
+    query: str
+    candidates: list[ChunkMatch]
+    top_k: int | None = None
+
+
+@dataclass(frozen=True)
+class RerankResult:
+    """Standard reranking output with stable ordering metadata."""
+
+    candidates: list[ChunkMatch]
+    original_order: list[str]
+    reranked_order: list[str]
+
+
+class RerankerProvider(ABC):
+    """Reorders retrieved chunks after initial retrieval, before context assembly."""
+
+    @abstractmethod
+    async def rerank(self, request: RerankRequest) -> RerankResult:
+        """Return candidates reordered by relevance to the query."""

--- a/backend/services/reranker/noop.py
+++ b/backend/services/reranker/noop.py
@@ -1,0 +1,20 @@
+"""Passthrough reranker used when reranking is disabled."""
+
+from __future__ import annotations
+
+from services.reranker.base import RerankRequest, RerankResult, RerankerProvider
+from services.reranker.similarity import _chunk_key
+
+
+class NoopRerankerProvider(RerankerProvider):
+    """Returns candidates unchanged."""
+
+    async def rerank(self, request: RerankRequest) -> RerankResult:
+        order = [_chunk_key(chunk) for chunk in request.candidates]
+        limit = request.top_k if request.top_k is not None else len(request.candidates)
+        candidates = request.candidates[:limit]
+        return RerankResult(
+            candidates=candidates,
+            original_order=order,
+            reranked_order=[_chunk_key(chunk) for chunk in candidates],
+        )

--- a/backend/services/reranker/similarity.py
+++ b/backend/services/reranker/similarity.py
@@ -1,0 +1,94 @@
+"""Deterministic baseline reranker using retrieval score and lexical overlap."""
+
+from __future__ import annotations
+
+import re
+
+from db.base import ChunkMatch
+
+from services.reranker.base import RerankRequest, RerankResult, RerankerProvider
+
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+
+
+def _chunk_key(chunk: ChunkMatch) -> str:
+    return chunk.id or f"{chunk.document_id}:{chunk.chunk_index}"
+
+
+def _tokenize(text: str) -> set[str]:
+    return {token.lower() for token in _TOKEN_PATTERN.findall(text or "")}
+
+
+def _lexical_overlap_score(query: str, chunk_text: str) -> float:
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return 0.0
+    chunk_tokens = _tokenize(chunk_text)
+    if not chunk_tokens:
+        return 0.0
+    return len(query_tokens & chunk_tokens) / len(query_tokens)
+
+
+def _retrieval_score(chunk: ChunkMatch) -> float:
+    if chunk.similarity is not None:
+        return float(chunk.similarity)
+    return 0.0
+
+
+class SimilarityRerankerProvider(RerankerProvider):
+    """
+    Baseline reranker: combine vector similarity with query/chunk token overlap.
+
+    No external models or GPU dependencies.
+    """
+
+    def __init__(self, *, retrieval_weight: float = 0.7, lexical_weight: float = 0.3):
+        total = retrieval_weight + lexical_weight
+        if total <= 0:
+            raise ValueError("retrieval_weight and lexical_weight must sum to a positive value")
+        self._retrieval_weight = retrieval_weight / total
+        self._lexical_weight = lexical_weight / total
+
+    async def rerank(self, request: RerankRequest) -> RerankResult:
+        original_order = [_chunk_key(chunk) for chunk in request.candidates]
+        if not request.candidates:
+            return RerankResult(
+                candidates=[],
+                original_order=original_order,
+                reranked_order=[],
+            )
+
+        scored: list[tuple[float, ChunkMatch]] = []
+        for chunk in request.candidates:
+            lexical = _lexical_overlap_score(request.query, chunk.chunk_text)
+            combined = (
+                self._retrieval_weight * _retrieval_score(chunk)
+                + self._lexical_weight * lexical
+            )
+            scored.append((combined, chunk))
+
+        scored.sort(key=lambda item: item[0], reverse=True)
+        limit = request.top_k if request.top_k is not None else len(scored)
+        reranked: list[ChunkMatch] = []
+        for combined_score, chunk in scored[:limit]:
+            reranked.append(
+                ChunkMatch(
+                    id=chunk.id,
+                    chunk_text=chunk.chunk_text,
+                    document_id=chunk.document_id,
+                    embedding=chunk.embedding,
+                    created_at=chunk.created_at,
+                    similarity=combined_score,
+                    chunk_index=chunk.chunk_index,
+                    page_number=chunk.page_number,
+                    character_offset_start=chunk.character_offset_start,
+                    character_offset_end=chunk.character_offset_end,
+                    file_name=chunk.file_name,
+                )
+            )
+
+        return RerankResult(
+            candidates=reranked,
+            original_order=original_order,
+            reranked_order=[_chunk_key(chunk) for chunk in reranked],
+        )

--- a/backend/services/retrieval_service.py
+++ b/backend/services/retrieval_service.py
@@ -1,0 +1,9 @@
+"""
+Retrieval orchestration helpers.
+
+Reranking runs after chunk retrieval and before context assembly.
+"""
+
+from services.reranker import rerank_chunks_if_enabled
+
+__all__ = ["rerank_chunks_if_enabled"]

--- a/backend/tests/test_reranker.py
+++ b/backend/tests/test_reranker.py
@@ -39,7 +39,16 @@ async def test_rerank_disabled_returns_original_order():
         result = await rerank_chunks_if_enabled("beta query", chunks, top_k=2)
 
     assert [c.id for c in result] == ["a", "b"]
-    assert isinstance(get_reranker_provider(), NoopRerankerProvider)
+
+
+@pytest.mark.asyncio
+async def test_rerank_disabled_does_not_truncate_to_top_k():
+    chunks = [_chunk(f"c{i}", f"content {i}", similarity=0.1) for i in range(6)]
+    with patch.object(config, "ENABLE_RERANKING", False):
+        result = await rerank_chunks_if_enabled("query", chunks, top_k=3)
+
+    assert len(result) == 6
+    assert [c.id for c in result] == [f"c{i}" for i in range(6)]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_reranker.py
+++ b/backend/tests/test_reranker.py
@@ -1,0 +1,95 @@
+"""Tests for retrieval reranking layer."""
+
+from unittest.mock import patch
+
+import pytest
+
+from core.config import config
+from db.base import ChunkMatch
+from services.reranker import _reset_reranker_provider, get_reranker_provider, rerank_chunks_if_enabled
+from services.reranker.base import RerankRequest
+from services.reranker.noop import NoopRerankerProvider
+from services.reranker.similarity import SimilarityRerankerProvider
+
+
+def _chunk(chunk_id: str, text: str, *, similarity: float | None = None) -> ChunkMatch:
+    return ChunkMatch(
+        id=chunk_id,
+        chunk_text=text,
+        document_id="doc-1",
+        chunk_index=0,
+        similarity=similarity,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_reranker_singleton():
+    _reset_reranker_provider()
+    yield
+    _reset_reranker_provider()
+
+
+@pytest.mark.asyncio
+async def test_rerank_disabled_returns_original_order():
+    chunks = [
+        _chunk("a", "alpha content", similarity=0.1),
+        _chunk("b", "beta content", similarity=0.9),
+    ]
+    with patch.object(config, "ENABLE_RERANKING", False):
+        result = await rerank_chunks_if_enabled("beta query", chunks, top_k=2)
+
+    assert [c.id for c in result] == ["a", "b"]
+    assert isinstance(get_reranker_provider(), NoopRerankerProvider)
+
+
+@pytest.mark.asyncio
+async def test_similarity_reranker_promotes_lexical_match():
+    chunks = [
+        _chunk("low", "unrelated text about cats", similarity=0.5),
+        _chunk("high", "beta query terms appear here", similarity=0.5),
+    ]
+    provider = SimilarityRerankerProvider()
+    result = await provider.rerank(
+        RerankRequest(query="beta query", candidates=chunks, top_k=2)
+    )
+
+    assert result.reranked_order[0] == "high"
+    assert result.original_order == ["low", "high"]
+    assert result.candidates[0].similarity is not None
+
+
+@pytest.mark.asyncio
+async def test_rerank_enabled_uses_provider_and_logs_order_change():
+    chunks = [
+        _chunk("low", "unrelated text about cats", similarity=0.5),
+        _chunk("high", "beta query terms appear here", similarity=0.5),
+    ]
+    with patch.object(config, "ENABLE_RERANKING", True), patch.object(
+        config, "RERANKER_PROVIDER", "similarity"
+    ):
+        _reset_reranker_provider()
+        result = await rerank_chunks_if_enabled("beta query", chunks, top_k=2)
+
+    assert [c.id for c in result] == ["high", "low"]
+    assert isinstance(get_reranker_provider(), SimilarityRerankerProvider)
+
+
+@pytest.mark.asyncio
+async def test_rerank_result_format_is_stable():
+    chunks = [_chunk("only", "single chunk", similarity=0.5)]
+    provider = SimilarityRerankerProvider()
+    result = await provider.rerank(RerankRequest(query="q", candidates=chunks))
+
+    assert result.original_order == ["only"]
+    assert result.reranked_order == ["only"]
+    assert len(result.candidates) == 1
+    assert result.candidates[0].chunk_text == "single chunk"
+
+
+def test_unknown_reranker_provider_raises():
+    with patch.object(config, "ENABLE_RERANKING", True), patch.object(
+        config, "RERANKER_PROVIDER", "unknown"
+    ):
+        _reset_reranker_provider()
+        with pytest.raises(ValueError, match="Unknown RERANKER_PROVIDER"):
+            get_reranker_provider()


### PR DESCRIPTION
## Summary
Closes #291

Adds an optional reranking layer after retrieval and before context assembly, with a deterministic similarity baseline and `ENABLE_RERANKING` config (off by default).

## Changes
- Introduce `RerankerProvider` abstraction with `RerankRequest` / `RerankResult` (`backend/services/reranker/`)
- Implement `SimilarityRerankerProvider` (retrieval score + lexical overlap) and `NoopRerankerProvider`
- Wire reranking into chat via `_finalize_retrieved_chunks()` on non-stream, stream, and batch paths
- Add `ENABLE_RERANKING` and `RERANKER_PROVIDER` config (documented in `.env.example`)
- Debug logging of original vs reranked chunk order when reranking is enabled
- When disabled, return all retrieved chunks unchanged (no `top_k` truncation on the rerank path)

## Testing
- `make tests` — 283 passed, 2 skipped
- Unit tests: reranking enabled/disabled, lexical reorder, stable result shape, unknown provider error
- Regression test: disabled reranking does not truncate merged chunks below `top_k`

## Migration steps
Optional env vars (defaults preserve current behavior):
- `ENABLE_RERANKING=false`
- `RERANKER_PROVIDER=similarity` (used when reranking is enabled)

## Notes for reviewer
- Reranking is opt-in; default path matches pre-change behavior for chunk count and order.
- When enabled, `SimilarityRerankerProvider` overwrites `ChunkMatch.similarity` with the combined rerank score (not raw vector similarity). Context assembly uses list order, not this field.
- No schema migrations.