### PR TITLE
fix(frontend): resolve horizontal scroll on About page mobile

### DIFF
--- a/frontend-demo/app/about/page.tsx
+++ b/frontend-demo/app/about/page.tsx
@@ -5,7 +5,7 @@ import Footer from "../components/home/Footer";
 export default function AboutPage() {
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <div className="max-w-[720px] mx-auto px-4 py-16 flex-1">
+      <div className="mx-auto w-full max-w-[720px] px-4 py-16 flex-1">
         {/* Section 1: What is ChatVector */}
         <section className="mb-20">
           <Kicker spacing="lg">what is chatvector</Kicker>


### PR DESCRIPTION
## What does this PR do?

Closes #281.

Fixes the About page content wrapper so it shrinks to the mobile viewport instead of expanding to its max-content width. This removes page-level horizontal scrolling while keeping the existing table `overflow-x-auto` behavior for narrow screens.

## How was it tested?

- [x] `safe-install npm ci`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm audit signatures`
- [x] Chrome headless viewport checks at 375px, 390px, 414px, and 1280px all reported `horizontalOverflow: 0`

## Screenshots (if UI changes):

Validated with mobile viewport checks; no redesign or visual content changes.