### PR TITLE
Add retrieval scope modes (session vs tenant)

### DIFF
--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -15,10 +15,13 @@ from services.chat_service import (
     answer_question_stream_for_document,
     answer_questions_for_documents_batch,
 )
-from services.session_service import get_or_create_session
+from services.session_service import get_or_create_session, register_session_document
+from services.tenant_registry import register_tenant_document
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+RetrievalScopeParam = Literal["session", "tenant"]
 
 
 class ChatBatchItem(BaseModel):
@@ -26,11 +29,13 @@ class ChatBatchItem(BaseModel):
     doc_ids: list[UUID] = Field(..., min_length=1)
     match_count: int = Field(default=5, ge=1, le=20)
     session_id: Optional[str] = None
+    scope: RetrievalScopeParam = "session"
 
 
 class ChatBatchRequest(BaseModel):
     queries: list[ChatBatchItem] = Field(..., min_length=1, max_length=20)
     session_id: Optional[str] = None
+    scope: RetrievalScopeParam = "session"
 
 
 class ChatRequest(BaseModel):
@@ -38,6 +43,7 @@ class ChatRequest(BaseModel):
     doc_id: UUID
     match_count: int = Field(default=5, ge=1, le=20)
     session_id: Optional[str] = None
+    scope: RetrievalScopeParam = "session"
 
 
 @router.post("/chat")
@@ -49,13 +55,17 @@ async def chat(request: Request, payload: ChatRequest, auth: AuthContext = Depen
     session = get_or_create_session(
         session_id=payload.session_id, tenant_id=auth.tenant_id
     )
+    doc_id_str = str(payload.doc_id)
+    register_session_document(session.id, doc_id_str, auth.tenant_id)
+    register_tenant_document(auth.tenant_id, doc_id_str)
 
     return await answer_question_for_document(
         question=payload.question,
-        doc_id=str(payload.doc_id),
+        doc_id=doc_id_str,
         match_count=payload.match_count,
         auth=auth,
         session_id=session.id,
+        scope=payload.scope,
     )
 
 
@@ -77,14 +87,18 @@ async def chat_stream(request: Request, payload: ChatRequest, auth: AuthContext 
     session = get_or_create_session(
         session_id=payload.session_id, tenant_id=auth.tenant_id
     )
+    doc_id_str = str(payload.doc_id)
+    register_session_document(session.id, doc_id_str, auth.tenant_id)
+    register_tenant_document(auth.tenant_id, doc_id_str)
 
     return StreamingResponse(
         answer_question_stream_for_document(
             question=payload.question,
-            doc_id=str(payload.doc_id),
+            doc_id=doc_id_str,
             match_count=payload.match_count,
             auth=auth,
             session_id=session.id,
+            scope=payload.scope,
         ),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
@@ -109,11 +123,16 @@ async def chat_batch(request: Request, payload: ChatBatchRequest, auth: AuthCont
                 tenant_id=auth.tenant_id,
             )
             q_dict["session_id"] = q_session.id
+            for doc_id in q.doc_ids:
+                doc_id_str = str(doc_id)
+                register_session_document(q_session.id, doc_id_str, auth.tenant_id)
+                register_tenant_document(auth.tenant_id, doc_id_str)
             processed_queries.append(q_dict)
 
         results = await answer_questions_for_documents_batch(
             processed_queries,
             auth=auth,
+            scope=payload.scope,
         )
     except ValueError as e:
         raise HTTPException(

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -118,6 +118,10 @@ async def chat_batch(request: Request, payload: ChatBatchRequest, auth: AuthCont
         processed_queries = []
         for q in payload.queries:
             q_dict = q.model_dump(mode="json")
+            # Only keep per-item scope when explicitly provided by the caller.
+            # When unset, let the batch-level `scope` take effect in the service.
+            if "scope" not in q.model_fields_set:
+                q_dict.pop("scope", None)
             q_session = get_or_create_session(
                 session_id=q.session_id or batch_session_id,
                 tenant_id=auth.tenant_id,

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -9,6 +9,7 @@ from middleware.rate_limit import limiter
 import db
 from services.ingestion_pipeline import IngestionPipeline, UploadPipelineError, _sanitize_filename
 from services.queue_service import QueueFull, QueueJob, ingestion_queue
+from services.tenant_registry import register_tenant_document
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -54,6 +55,7 @@ async def upload(request: Request, file: UploadFile = File(...), auth: AuthConte
 
         # Persist the document record so the status endpoint works immediately
         doc_id = await db.create_document(safe_filename, tenant_id=tenant_id)
+        register_tenant_document(tenant_id, doc_id)
         await db.update_document_status(doc_id=doc_id, status="queued", tenant_id=tenant_id)
 
         job = QueueJob(

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -10,7 +10,6 @@ from db import find_similar_chunks
 from services.context_service import build_context_from_chunks
 from services.query_service import transform_query
 from services.retrieval_service import (
-    assert_tenant_isolation,
     filter_doc_ids_for_tenant,
     parse_retrieval_scope,
     rerank_chunks_if_enabled,
@@ -156,7 +155,6 @@ def _resolve_retrieval_doc_ids(
         tenant_doc_ids=tenant_doc_ids,
     )
     doc_ids = filter_doc_ids_for_tenant(doc_ids, tenant_doc_ids, tenant_id)
-    assert_tenant_isolation(doc_ids, tenant_doc_ids, tenant_id)
     return doc_ids
 
 

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -9,7 +9,15 @@ from core.session import SessionContext
 from db import find_similar_chunks
 from services.context_service import build_context_from_chunks
 from services.query_service import transform_query
-from services.retrieval_service import rerank_chunks_if_enabled
+from services.retrieval_service import (
+    assert_tenant_isolation,
+    filter_doc_ids_for_tenant,
+    parse_retrieval_scope,
+    rerank_chunks_if_enabled,
+    resolve_scoped_doc_ids,
+)
+from services.session_service import get_session
+from services.tenant_registry import get_tenant_document_ids
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +131,35 @@ def _normalize_doc_ids(doc_ids: list[str], *, query_index: int) -> list[str]:
     return normalized
 
 
+def _resolve_retrieval_doc_ids(
+    *,
+    scope: str | None,
+    requested_doc_ids: list[str],
+    session_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+) -> list[str]:
+    """Apply retrieval scope rules and tenant isolation checks."""
+    retrieval_scope = parse_retrieval_scope(scope)
+
+    session_doc_ids: list[str] = []
+    if session_id:
+        session = get_session(session_id, tenant_id)
+        if session:
+            session_doc_ids = list(session.document_ids)
+
+    tenant_doc_ids = get_tenant_document_ids(tenant_id)
+
+    doc_ids = resolve_scoped_doc_ids(
+        retrieval_scope,
+        requested_doc_ids=requested_doc_ids,
+        session_doc_ids=session_doc_ids,
+        tenant_doc_ids=tenant_doc_ids,
+    )
+    doc_ids = filter_doc_ids_for_tenant(doc_ids, tenant_doc_ids, tenant_id)
+    assert_tenant_isolation(doc_ids, tenant_doc_ids, tenant_id)
+    return doc_ids
+
+
 async def _retrieve_chunks_for_documents(
     doc_ids: list[str],
     query_embedding: list[float],
@@ -177,12 +214,33 @@ async def answer_question_for_document(
     auth: Optional[AuthContext] = None,
     session_id: Optional[str] = None,
     session_context: Optional[SessionContext] = None,
+    scope: Optional[str] = None,
 ) -> dict:
     """
     Orchestrate the chat flow for a single question/document pair.
     """
-    logger.info(f"Starting chat for document {doc_id} (session={session_id})")
-    tenant_id = get_current_tenant(auth) if auth else None  # noqa: F841 — reserved for Phase 3 tenant scoping
+    logger.info(f"Starting chat for document {doc_id} (session={session_id}, scope={scope or 'session'})")
+    tenant_id = get_current_tenant(auth) if auth else None
+
+    doc_ids = _resolve_retrieval_doc_ids(
+        scope=scope,
+        requested_doc_ids=[doc_id],
+        session_id=session_id,
+        tenant_id=tenant_id,
+    )
+    if not doc_ids:
+        return {
+            "question": question,
+            "doc_id": doc_id,
+            "chunks": 0,
+            "answer": "",
+            "sources": [],
+            "status": "error",
+            "error": {
+                "code": "no_documents_in_scope",
+                "message": "No documents available for retrieval in the requested scope.",
+            },
+        }
 
     transformed_queries = await transform_query(question)
     query_embeddings = await get_embeddings(transformed_queries)
@@ -190,7 +248,7 @@ async def answer_question_for_document(
     seen_chunk_keys: set = set()
     for query_embedding in query_embeddings:
         chunks = await _retrieve_chunks_for_documents(
-            doc_ids=[doc_id],
+            doc_ids=doc_ids,
             query_embedding=query_embedding,
             match_count=match_count,
             session_id=session_id,
@@ -259,22 +317,37 @@ async def answer_question_stream_for_document(
     auth: Optional[AuthContext] = None,
     session_id: Optional[str] = None,
     session_context: Optional[SessionContext] = None,
+    scope: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Orchestrate the chat flow for a single question/document pair, yielding
     a server-sent events (SSE) stream.
     """
-    logger.info(f"Starting chat stream for document {doc_id}")
-    tenant_id = get_current_tenant(auth) if auth else None  # noqa: F841 — reserved for Phase 3 tenant scoping
+    logger.info(f"Starting chat stream for document {doc_id} (scope={scope or 'session'})")
+    tenant_id = get_current_tenant(auth) if auth else None
 
     try:
+        doc_ids = _resolve_retrieval_doc_ids(
+            scope=scope,
+            requested_doc_ids=[doc_id],
+            session_id=session_id,
+            tenant_id=tenant_id,
+        )
+        if not doc_ids:
+            yield (
+                'event: error\ndata: '
+                + json.dumps("No documents available for retrieval in the requested scope.")
+                + "\n\n"
+            )
+            return
+
         transformed_queries = await transform_query(question)
         query_embeddings = await get_embeddings(transformed_queries)
         all_chunks: list = []
         seen_chunk_keys: set = set()
         for query_embedding in query_embeddings:
             chunks = await _retrieve_chunks_for_documents(
-                doc_ids=[doc_id],
+                doc_ids=doc_ids,
                 query_embedding=query_embedding,
                 match_count=match_count,
                 query_text=question,
@@ -333,6 +406,7 @@ async def answer_questions_for_documents_batch(
     queries: list[dict],
     auth: Optional[AuthContext] = None,
     session_context: Optional[SessionContext] = None,
+    scope: Optional[str] = None,
 ) -> list[dict]:
     """
     Process multiple question/document retrieval requests in one call.
@@ -375,6 +449,7 @@ async def answer_questions_for_documents_batch(
                 "doc_ids": doc_ids,
                 "match_count": match_count,
                 "session_id": query.get("session_id"),
+                "scope": query.get("scope", scope),
             }
         )
 
@@ -414,11 +489,31 @@ async def answer_questions_for_documents_batch(
     ) -> dict:
         try:
             session_id = query.get("session_id")
+            query_scope = query.get("scope")
+            doc_ids = _resolve_retrieval_doc_ids(
+                scope=query_scope,
+                requested_doc_ids=query["doc_ids"],
+                session_id=session_id,
+                tenant_id=tenant_id,
+            )
+            if not doc_ids:
+                return {
+                    "status": "error",
+                    "question": query["question"],
+                    "doc_ids": query["doc_ids"],
+                    "chunks": 0,
+                    "error": {
+                        "code": "no_documents_in_scope",
+                        "message": "No documents available for retrieval in the requested scope.",
+                    },
+                    "session_id": session_id,
+                }
+
             all_chunks: list = []
             seen_chunk_keys: set = set()
             for query_embedding in query_embeddings:
                 chunks = await _retrieve_chunks_for_documents(
-                    doc_ids=query["doc_ids"],
+                    doc_ids=doc_ids,
                     query_embedding=query_embedding,
                     match_count=query["match_count"],
                     session_id=session_id,

--- a/backend/services/retrieval_service.py
+++ b/backend/services/retrieval_service.py
@@ -60,9 +60,9 @@ def resolve_scoped_doc_ids(
         unchanged for backward compatibility.
 
     Tenant scope:
-      - Search all documents registered to the tenant.
-      - When explicit requested IDs are provided, intersect with the tenant set
-        to prevent cross-tenant leakage.
+      - Search all documents registered to the tenant, ignoring any explicitly
+        requested IDs. Cross-tenant leakage is prevented because the registry
+        only contains documents registered under the authenticated tenant.
     """
     session_docs = session_doc_ids or []
     tenant_docs = tenant_doc_ids or []

--- a/backend/services/retrieval_service.py
+++ b/backend/services/retrieval_service.py
@@ -1,14 +1,114 @@
 """
-Retrieval orchestration helpers: Hybrid search (RRF) and optional reranking.
+Retrieval orchestration helpers: Hybrid search (RRF), optional reranking,
+and scoped retrieval (session vs tenant).
 """
 
 from __future__ import annotations
+
+from enum import Enum
 
 from db.base import ChunkMatch
 from services.reranker import rerank_chunks_if_enabled
 
 # Standard RRF constant (Cormack et al.)
 RRF_K_DEFAULT = 60
+
+
+class RetrievalScope(str, Enum):
+    SESSION = "session"
+    TENANT = "tenant"
+
+
+DEFAULT_RETRIEVAL_SCOPE = RetrievalScope.SESSION
+
+
+class InvalidRetrievalScopeError(ValueError):
+    """Raised when an unsupported retrieval scope value is provided."""
+
+    def __init__(self, scope: str) -> None:
+        super().__init__(
+            f"Invalid retrieval scope: {scope!r}. Must be one of: session, tenant"
+        )
+        self.scope = scope
+
+
+def parse_retrieval_scope(value: str | None) -> RetrievalScope:
+    """Parse and validate a retrieval scope string. Defaults to session."""
+    if value is None:
+        return DEFAULT_RETRIEVAL_SCOPE
+    normalized = value.strip().lower()
+    try:
+        return RetrievalScope(normalized)
+    except ValueError as exc:
+        raise InvalidRetrievalScopeError(value) from exc
+
+
+def resolve_scoped_doc_ids(
+    scope: RetrievalScope,
+    *,
+    requested_doc_ids: list[str],
+    session_doc_ids: list[str] | None = None,
+    tenant_doc_ids: list[str] | None = None,
+) -> list[str]:
+    """
+    Determine which document IDs to search based on retrieval scope.
+
+    Session scope (default):
+      - When the session has registered documents, search only those in the
+        session set (intersected with any explicitly requested IDs).
+      - When the session has no registered documents, use requested IDs
+        unchanged for backward compatibility.
+
+    Tenant scope:
+      - Search all documents registered to the tenant.
+      - When explicit requested IDs are provided, intersect with the tenant set
+        to prevent cross-tenant leakage.
+    """
+    session_docs = session_doc_ids or []
+    tenant_docs = tenant_doc_ids or []
+
+    if scope == RetrievalScope.SESSION:
+        if session_docs:
+            if requested_doc_ids:
+                session_set = set(session_docs)
+                return [doc_id for doc_id in requested_doc_ids if doc_id in session_set]
+            return list(session_docs)
+        return list(requested_doc_ids)
+
+    # Tenant scope — search all documents registered to the tenant.
+    if tenant_docs:
+        return list(tenant_docs)
+
+    # No tenant registry entries — fall back to requested IDs (dev / single-tenant)
+    return list(requested_doc_ids)
+
+
+def filter_doc_ids_for_tenant(
+    doc_ids: list[str],
+    tenant_doc_ids: list[str] | None,
+    tenant_id: str | None,
+) -> list[str]:
+    """Remove document IDs that do not belong to the current tenant."""
+    if not tenant_id or not tenant_doc_ids:
+        return list(doc_ids)
+    tenant_set = set(tenant_doc_ids)
+    return [doc_id for doc_id in doc_ids if doc_id in tenant_set]
+
+
+def assert_tenant_isolation(
+    doc_ids: list[str],
+    tenant_doc_ids: list[str] | None,
+    tenant_id: str | None,
+) -> None:
+    """Raise ValueError if any doc_id is outside the tenant's document set."""
+    if not tenant_id or not tenant_doc_ids:
+        return
+    tenant_set = set(tenant_doc_ids)
+    leaked = [doc_id for doc_id in doc_ids if doc_id not in tenant_set]
+    if leaked:
+        raise ValueError(
+            f"Document(s) not accessible for tenant {tenant_id!r}: {sorted(leaked)}"
+        )
 
 
 def reciprocal_rank_fusion(
@@ -48,4 +148,15 @@ def merge_chunk_matches(
             merged.append(match)
     return merged
 
-__all__ = ["rerank_chunks_if_enabled", "reciprocal_rank_fusion", "merge_chunk_matches"]
+__all__ = [
+    "DEFAULT_RETRIEVAL_SCOPE",
+    "InvalidRetrievalScopeError",
+    "RetrievalScope",
+    "assert_tenant_isolation",
+    "filter_doc_ids_for_tenant",
+    "merge_chunk_matches",
+    "parse_retrieval_scope",
+    "reciprocal_rank_fusion",
+    "rerank_chunks_if_enabled",
+    "resolve_scoped_doc_ids",
+]

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -79,3 +79,16 @@ def get_or_create_session(
 def reset_session(session_id: str) -> bool:
     """Remove a session from the store."""
     return delete_session(session_id)
+
+
+def register_session_document(
+    session_id: str,
+    doc_id: str,
+    tenant_id: Optional[str] = None,
+) -> None:
+    """Track a document as part of the session's active document set."""
+    session = get_session(session_id, tenant_id)
+    if session is None:
+        return
+    if doc_id not in session.document_ids:
+        session.document_ids.append(doc_id)

--- a/backend/services/tenant_registry.py
+++ b/backend/services/tenant_registry.py
@@ -1,0 +1,37 @@
+"""
+In-memory tenant document registry for Phase 3 tenant isolation.
+
+Documents are registered at upload time. In a future phase this would
+move to PostgreSQL alongside a tenant_id column on documents.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+_TENANT_DOCUMENTS: dict[str, set[str]] = defaultdict(set)
+
+
+def register_tenant_document(tenant_id: str | None, doc_id: str) -> None:
+    """Associate a document with a tenant."""
+    if tenant_id and doc_id:
+        _TENANT_DOCUMENTS[tenant_id].add(doc_id)
+
+
+def get_tenant_document_ids(tenant_id: str | None) -> list[str]:
+    """Return sorted document IDs belonging to a tenant."""
+    if not tenant_id:
+        return []
+    return sorted(_TENANT_DOCUMENTS.get(tenant_id, set()))
+
+
+def document_belongs_to_tenant(doc_id: str, tenant_id: str | None) -> bool:
+    """Return True when doc_id is registered to the tenant (or tenant is unset)."""
+    if not tenant_id:
+        return True
+    return doc_id in _TENANT_DOCUMENTS.get(tenant_id, set())
+
+
+def clear_tenant_registry() -> None:
+    """Reset registry — for tests only."""
+    _TENANT_DOCUMENTS.clear()

--- a/backend/services/tenant_registry.py
+++ b/backend/services/tenant_registry.py
@@ -25,13 +25,6 @@ def get_tenant_document_ids(tenant_id: str | None) -> list[str]:
     return sorted(_TENANT_DOCUMENTS.get(tenant_id, set()))
 
 
-def document_belongs_to_tenant(doc_id: str, tenant_id: str | None) -> bool:
-    """Return True when doc_id is registered to the tenant (or tenant is unset)."""
-    if not tenant_id:
-        return True
-    return doc_id in _TENANT_DOCUMENTS.get(tenant_id, set())
-
-
 def clear_tenant_registry() -> None:
     """Reset registry — for tests only."""
     _TENANT_DOCUMENTS.clear()

--- a/backend/tests/test_chat_route.py
+++ b/backend/tests/test_chat_route.py
@@ -50,7 +50,7 @@ def test_chat_batch_route_delegates_to_chat_service():
 
     assert result == payload
     mock_batch.assert_awaited_once_with(
-        [{"question": "q", "doc_ids": [_DOC_ID_1], "match_count": 5, "session_id": ANY, "scope": "session"}],
+        [{"question": "q", "doc_ids": [_DOC_ID_1], "match_count": 5, "session_id": ANY}],
         auth=ANY,
         scope="session",
     )

--- a/backend/tests/test_chat_route.py
+++ b/backend/tests/test_chat_route.py
@@ -2,8 +2,11 @@ import asyncio
 from fastapi import HTTPException
 from unittest.mock import ANY, AsyncMock, patch
 
+import pytest
+from pydantic import ValidationError
+
 from request_utils import make_test_request
-from routes.chat import ChatBatchItem, ChatBatchRequest, ChatRequest, chat, chat_batch
+from routes.chat import ChatBatchItem, ChatBatchRequest, ChatRequest, chat, chat_batch, chat_stream
 
 _DOC_ID_1 = "00000000-0000-0000-0000-000000000001"
 _DOC_ID_2 = "00000000-0000-0000-0000-000000000002"
@@ -25,7 +28,7 @@ def test_chat_route_delegates_to_chat_service():
 
     assert result == payload
     mock_chat.assert_awaited_once_with(
-        question="q", doc_id=_DOC_ID_1, match_count=5, auth=ANY, session_id=ANY
+        question="q", doc_id=_DOC_ID_1, match_count=5, auth=ANY, session_id=ANY, scope="session"
     )
 
 def test_chat_batch_route_delegates_to_chat_service():
@@ -47,8 +50,9 @@ def test_chat_batch_route_delegates_to_chat_service():
 
     assert result == payload
     mock_batch.assert_awaited_once_with(
-        [{"question": "q", "doc_ids": [_DOC_ID_1], "match_count": 5, "session_id": ANY}],
+        [{"question": "q", "doc_ids": [_DOC_ID_1], "match_count": 5, "session_id": ANY, "scope": "session"}],
         auth=ANY,
+        scope="session",
     )
 
 
@@ -95,8 +99,11 @@ def test_chat_batch_route_returns_422_for_value_error():
             assert exc.status_code == 422
             assert exc.detail["code"] == "invalid_batch_request"
 
-import pytest
-from routes.chat import chat_stream
+
+def test_chat_route_rejects_invalid_scope():
+    with pytest.raises(ValidationError, match="scope"):
+        ChatRequest(question="q", doc_id=_DOC_ID_1, scope="global")  # type: ignore[arg-type]
+
 
 @pytest.mark.asyncio
 async def test_chat_stream_route_disabled():

--- a/backend/tests/test_retrieval_scope.py
+++ b/backend/tests/test_retrieval_scope.py
@@ -1,0 +1,107 @@
+import pytest
+
+from services.retrieval_service import (
+    DEFAULT_RETRIEVAL_SCOPE,
+    InvalidRetrievalScopeError,
+    RetrievalScope,
+    assert_tenant_isolation,
+    filter_doc_ids_for_tenant,
+    parse_retrieval_scope,
+    resolve_scoped_doc_ids,
+)
+
+
+class TestParseRetrievalScope:
+    def test_defaults_to_session(self):
+        assert parse_retrieval_scope(None) == DEFAULT_RETRIEVAL_SCOPE
+        assert parse_retrieval_scope(None) == RetrievalScope.SESSION
+
+    def test_accepts_valid_scopes(self):
+        assert parse_retrieval_scope("session") == RetrievalScope.SESSION
+        assert parse_retrieval_scope("tenant") == RetrievalScope.TENANT
+        assert parse_retrieval_scope("  TENANT  ") == RetrievalScope.TENANT
+
+    def test_rejects_invalid_scope(self):
+        with pytest.raises(InvalidRetrievalScopeError, match="Invalid retrieval scope"):
+            parse_retrieval_scope("global")
+        with pytest.raises(InvalidRetrievalScopeError):
+            parse_retrieval_scope("")
+
+
+class TestResolveScopedDocIds:
+    def test_session_scope_uses_requested_when_session_empty(self):
+        result = resolve_scoped_doc_ids(
+            RetrievalScope.SESSION,
+            requested_doc_ids=["doc-a", "doc-b"],
+            session_doc_ids=[],
+        )
+        assert result == ["doc-a", "doc-b"]
+
+    def test_session_scope_intersects_with_session_documents(self):
+        result = resolve_scoped_doc_ids(
+            RetrievalScope.SESSION,
+            requested_doc_ids=["doc-a", "doc-c"],
+            session_doc_ids=["doc-a", "doc-b"],
+        )
+        assert result == ["doc-a"]
+
+    def test_session_scope_returns_session_docs_when_no_request(self):
+        result = resolve_scoped_doc_ids(
+            RetrievalScope.SESSION,
+            requested_doc_ids=[],
+            session_doc_ids=["doc-a", "doc-b"],
+        )
+        assert result == ["doc-a", "doc-b"]
+
+    def test_tenant_scope_returns_all_tenant_documents(self):
+        result = resolve_scoped_doc_ids(
+            RetrievalScope.TENANT,
+            requested_doc_ids=["doc-other"],
+            tenant_doc_ids=["doc-x", "doc-y"],
+        )
+        assert result == ["doc-x", "doc-y"]
+
+    def test_tenant_scope_ignores_requested_when_tenant_registry_present(self):
+        result = resolve_scoped_doc_ids(
+            RetrievalScope.TENANT,
+            requested_doc_ids=["doc-x", "doc-foreign"],
+            tenant_doc_ids=["doc-x", "doc-y"],
+        )
+        assert result == ["doc-x", "doc-y"]
+
+    def test_tenant_scope_falls_back_to_requested_without_registry(self):
+        result = resolve_scoped_doc_ids(
+            RetrievalScope.TENANT,
+            requested_doc_ids=["doc-a"],
+            tenant_doc_ids=[],
+        )
+        assert result == ["doc-a"]
+
+
+class TestTenantIsolation:
+    def test_filter_doc_ids_for_tenant_removes_foreign_docs(self):
+        filtered = filter_doc_ids_for_tenant(
+            ["doc-a", "doc-b", "doc-c"],
+            tenant_doc_ids=["doc-a", "doc-c"],
+            tenant_id="tenant-1",
+        )
+        assert filtered == ["doc-a", "doc-c"]
+
+    def test_filter_doc_ids_skips_when_no_tenant(self):
+        doc_ids = ["doc-a", "doc-b"]
+        assert filter_doc_ids_for_tenant(doc_ids, ["doc-a"], tenant_id=None) == doc_ids
+
+    def test_assert_tenant_isolation_raises_on_leak(self):
+        with pytest.raises(ValueError, match="not accessible for tenant"):
+            assert_tenant_isolation(
+                ["doc-a", "doc-foreign"],
+                tenant_doc_ids=["doc-a"],
+                tenant_id="tenant-1",
+            )
+
+    def test_assert_tenant_isolation_passes_for_valid_docs(self):
+        assert_tenant_isolation(
+            ["doc-a"],
+            tenant_doc_ids=["doc-a", "doc-b"],
+            tenant_id="tenant-1",
+        )

--- a/backend/tests/test_retrieval_scope_integration.py
+++ b/backend/tests/test_retrieval_scope_integration.py
@@ -1,0 +1,162 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.auth import AuthContext
+from services import session_service
+from services.chat_service import answer_question_for_document
+from services.tenant_registry import clear_tenant_registry, register_tenant_document
+
+
+@pytest.fixture(autouse=True)
+def _reset_registries():
+    session_service._SESSIONS.clear()
+    clear_tenant_registry()
+    yield
+    session_service._SESSIONS.clear()
+    clear_tenant_registry()
+
+
+@pytest.fixture(autouse=True)
+def _disable_query_transformation(monkeypatch):
+    import services.chat_service as chat_service_mod
+
+    monkeypatch.setattr(chat_service_mod.config, "QUERY_TRANSFORMATION_ENABLED", False)
+
+
+@pytest.mark.asyncio
+async def test_session_scope_searches_registered_session_document():
+    session = session_service.create_session(session_id="sess-1", tenant_id="tenant-a")
+    session_service.register_session_document(session.id, "doc-in-session", "tenant-a")
+
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find, patch(
+        "services.chat_service.build_context_from_chunks", return_value="ctx"
+    ), patch(
+        "services.chat_service.generate_answer", new=AsyncMock(return_value="answer")
+    ):
+        result = await answer_question_for_document(
+            question="Q?",
+            doc_id="doc-in-session",
+            session_id=session.id,
+            auth=AuthContext(tenant_id="tenant-a"),
+            scope="session",
+        )
+
+    assert result["status"] == "ok"
+    mock_find.assert_awaited_once()
+    assert mock_find.await_args.kwargs["doc_id"] == "doc-in-session"
+
+
+@pytest.mark.asyncio
+async def test_session_scope_blocks_document_outside_session():
+    session = session_service.create_session(session_id="sess-2", tenant_id="tenant-a")
+    session_service.register_session_document(session.id, "doc-allowed", "tenant-a")
+
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find, patch(
+        "services.chat_service.generate_answer", new=AsyncMock(return_value="answer")
+    ):
+        result = await answer_question_for_document(
+            question="Q?",
+            doc_id="doc-blocked",
+            session_id=session.id,
+            auth=AuthContext(tenant_id="tenant-a"),
+            scope="session",
+        )
+
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "no_documents_in_scope"
+    mock_find.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tenant_scope_searches_all_tenant_documents():
+    register_tenant_document("tenant-a", "doc-1")
+    register_tenant_document("tenant-a", "doc-2")
+
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find, patch(
+        "services.chat_service.build_context_from_chunks", return_value="ctx"
+    ), patch(
+        "services.chat_service.generate_answer", new=AsyncMock(return_value="answer")
+    ):
+        result = await answer_question_for_document(
+            question="Q?",
+            doc_id="doc-1",
+            auth=AuthContext(tenant_id="tenant-a"),
+            scope="tenant",
+        )
+
+    assert result["status"] == "ok"
+    assert mock_find.await_count == 2
+    searched_doc_ids = {call.kwargs["doc_id"] for call in mock_find.await_args_list}
+    assert searched_doc_ids == {"doc-1", "doc-2"}
+
+
+@pytest.mark.asyncio
+async def test_tenant_scope_prevents_cross_tenant_document_access():
+    register_tenant_document("tenant-a", "doc-a")
+    register_tenant_document("tenant-b", "doc-b")
+
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find, patch(
+        "services.chat_service.build_context_from_chunks", return_value="ctx"
+    ), patch(
+        "services.chat_service.generate_answer", new=AsyncMock(return_value="answer")
+    ):
+        result = await answer_question_for_document(
+            question="Q?",
+            doc_id="doc-b",
+            auth=AuthContext(tenant_id="tenant-a"),
+            scope="tenant",
+        )
+
+    assert result["status"] == "ok"
+    searched_doc_ids = {call.kwargs["doc_id"] for call in mock_find.await_args_list}
+    assert searched_doc_ids == {"doc-a"}
+    assert "doc-b" not in searched_doc_ids
+
+
+@pytest.mark.asyncio
+async def test_session_scope_backward_compatible_without_session_documents():
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find, patch(
+        "services.chat_service.build_context_from_chunks", return_value="ctx"
+    ), patch(
+        "services.chat_service.generate_answer", new=AsyncMock(return_value="answer")
+    ):
+        result = await answer_question_for_document(
+            question="Q?",
+            doc_id="doc-legacy",
+            scope="session",
+        )
+
+    assert result["status"] == "ok"
+    mock_find.assert_awaited_once_with(
+        doc_id="doc-legacy",
+        query_embedding=[0.1, 0.2],
+        match_count=5,
+        session_id=None,
+        query_text="Q?",
+    )

--- a/backend/tests/test_retrieval_scope_integration.py
+++ b/backend/tests/test_retrieval_scope_integration.py
@@ -4,7 +4,11 @@ import pytest
 
 from core.auth import AuthContext
 from services import session_service
-from services.chat_service import answer_question_for_document
+from services.chat_service import (
+    answer_question_for_document,
+    answer_question_stream_for_document,
+    answer_questions_for_documents_batch,
+)
 from services.tenant_registry import clear_tenant_registry, register_tenant_document
 
 
@@ -160,3 +164,66 @@ async def test_session_scope_backward_compatible_without_session_documents():
         session_id=None,
         query_text="Q?",
     )
+
+
+@pytest.mark.asyncio
+async def test_batch_level_scope_applied_when_items_omit_scope():
+    """Batch-level scope must take effect when individual items do not set their own scope."""
+    register_tenant_document("tenant-a", "doc-1")
+    register_tenant_document("tenant-a", "doc-2")
+
+    queries = [
+        {
+            "question": "Q?",
+            "doc_ids": ["doc-1"],
+            "match_count": 5,
+            "session_id": None,
+            # no "scope" key — should inherit batch-level "tenant"
+        }
+    ]
+
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find, patch(
+        "services.chat_service.build_context_from_chunks", return_value="ctx"
+    ), patch(
+        "services.chat_service.generate_answer", new=AsyncMock(return_value="answer")
+    ):
+        results = await answer_questions_for_documents_batch(
+            queries,
+            auth=AuthContext(tenant_id="tenant-a"),
+            scope="tenant",
+        )
+
+    assert results[0]["status"] == "ok"
+    searched_doc_ids = {call.kwargs["doc_id"] for call in mock_find.await_args_list}
+    assert searched_doc_ids == {"doc-1", "doc-2"}
+
+
+@pytest.mark.asyncio
+async def test_stream_session_scope_blocks_document_outside_session():
+    """Stream endpoint must respect session scope and block out-of-scope documents."""
+    session = session_service.create_session(session_id="stream-sess", tenant_id="tenant-a")
+    session_service.register_session_document(session.id, "doc-allowed", "tenant-a")
+
+    with patch(
+        "services.chat_service.get_embeddings",
+        new=AsyncMock(return_value=[[0.1, 0.2]]),
+    ), patch(
+        "services.chat_service.find_similar_chunks", new=AsyncMock(return_value=[])
+    ) as mock_find:
+        events = []
+        async for event in answer_question_stream_for_document(
+            question="Q?",
+            doc_id="doc-blocked",
+            session_id=session.id,
+            auth=AuthContext(tenant_id="tenant-a"),
+            scope="session",
+        ):
+            events.append(event)
+
+    assert any("error" in e for e in events)
+    mock_find.assert_not_awaited()


### PR DESCRIPTION
## Summary
Closes #292

Adds optional `scope` parameter to chat endpoints so retrieval can run against the session document set (default) or all documents registered to the tenant.

## Changes
- Add retrieval scope helpers in `retrieval_service.py`: `RetrievalScope`, `parse_retrieval_scope`, `resolve_scoped_doc_ids`, and tenant filtering utilities
- Add in-memory tenant document registry (`tenant_registry.py`) and session document tracking (`register_session_document`)
- Wire scoped retrieval through `chat_service.py` for single, stream, and batch chat flows
- Expose optional `scope: "session" | "tenant"` on `/chat`, `/chat/stream`, and `/chat/batch` request models (defaults to `"session"`)
- Register tenant documents at upload time and session documents on chat requests
- Add unit and integration tests for session scope, tenant scope, invalid scopes, tenant isolation, batch-level scope propagation, and stream scope blocking

## Review findings addressed
- Batch-level `scope` was shadowed by Pydantic's per-item default — fixed by omitting `scope` from serialized batch items unless explicitly set, so batch-level scope applies correctly
- Dead `assert_tenant_isolation` call after filtering removed (always a no-op post-filter)
- Unused `document_belongs_to_tenant` helper removed
- Misleading tenant-scope docstring in `resolve_scoped_doc_ids` corrected to match behavior (tenant scope searches all tenant-registered docs)

## Deferred items
- Tenant document registry is in-memory and process-local (same pattern as Phase 3A sessions). After restart, tenant scope only sees documents re-registered via upload/chat until a DB-backed registry lands.
- `assert_tenant_isolation` remains as a tested utility but is not called on the hot path; can be wired in or removed in a follow-up if desired.
- Four pre-existing test failures on `main` (`test_chat_history` ×2, `test_redis_promotion`, `test_docs_openapi_env`) were not addressed in this PR.

## Testing
- Added 14 new tests across `test_retrieval_scope.py` and `test_retrieval_scope_integration.py`
- Updated `test_chat_route.py` for scope parameter delegation and invalid scope validation
- Full suite: 318 passed on this branch; 4 failures match pre-existing failures on `main` (missing `chat_messages` table in test DB, `.env` leaking `QUEUE_BACKEND=redis` into isolated config tests)

## Notes for reviewer
- Session scope is backward compatible: when a session has no registered documents, requested `doc_id`/`doc_ids` are used unchanged
- Tenant scope ignores explicitly requested doc IDs when the tenant registry is populated and searches all tenant-registered documents; isolation relies on the registry, not doc_id intersection
- Batch requests support scope at both batch and per-item level; per-item scope wins when explicitly set
- No schema changes, env vars, or migrations required