### PR TITLE
Fix config tests leaking backend/.env values

### DIFF
--- a/backend/tests/test_docs_openapi_env.py
+++ b/backend/tests/test_docs_openapi_env.py
@@ -1,9 +1,24 @@
 """OpenAPI / docs URLs depend on APP_ENV (see main.FastAPI configuration)."""
 
 import importlib
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+
+
+def _reload_app(monkeypatch, app_env: str):
+    """Reload config/main for the requested APP_ENV."""
+    monkeypatch.setenv("APP_ENV", app_env)
+    if app_env == "development":
+        # Prevent backend/.env QUEUE_BACKEND=redis from enabling Redis startup in dev tests.
+        monkeypatch.setenv("QUEUE_BACKEND", "memory")
+    import core.config
+    import main
+
+    importlib.reload(core.config)
+    importlib.reload(main)
+    return main
 
 
 @pytest.fixture(autouse=True)
@@ -15,40 +30,25 @@ def _restore_main_after_test(monkeypatch):
 
     importlib.reload(core.config)
     importlib.reload(main)
+
+
 def test_docs_returns_404_when_app_env_production(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "production")
-    import core.config
-    import main
+    main = _reload_app(monkeypatch, "production")
 
-    importlib.reload(core.config)
-    importlib.reload(main)
-
-    from unittest.mock import patch, AsyncMock
     with patch("core.clients.redis_client.ping", new_callable=AsyncMock), TestClient(main.app) as client:
-        # /docs
         response = client.get("/docs")
         assert response.status_code == 404
 
 
 def test_docs_returns_200_when_app_env_development(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "development")
-    import core.config
-    import main
-
-    importlib.reload(core.config)
-    importlib.reload(main)
+    main = _reload_app(monkeypatch, "development")
 
     with TestClient(main.app) as client:
         assert client.get("/docs").status_code == 200
 
 
 def test_global_exception_handler_masks_errors(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "development")
-    import core.config
-    import main
-
-    importlib.reload(core.config)
-    importlib.reload(main)
+    main = _reload_app(monkeypatch, "development")
 
     @main.app.get("/force-error-for-test")
     def force_error():
@@ -59,8 +59,8 @@ def test_global_exception_handler_masks_errors(monkeypatch):
 
     assert response.status_code == 500
     data = response.json()
-    
+
     assert data["detail"]["code"] == "internal_error"
     assert data["detail"]["message"] == "An unexpected error occurred."
-    
+
     assert "SENSITIVE_DB_PASSWORD_LEAK" not in response.text

--- a/backend/tests/test_redis_promotion.py
+++ b/backend/tests/test_redis_promotion.py
@@ -1,20 +1,23 @@
-import os
 import importlib
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 
-def test_queue_backend_default_development():
+def test_queue_backend_default_development(monkeypatch):
     """Verify memory queue is default when APP_ENV is development."""
-    with patch.dict(os.environ, {"APP_ENV": "development"}, clear=True):
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.delenv("QUEUE_BACKEND", raising=False)
+    with patch("dotenv.load_dotenv"):
         import core.config
         importlib.reload(core.config)
         config = core.config.Settings()
         assert config.QUEUE_BACKEND == "memory"
 
-def test_queue_backend_default_production():
+def test_queue_backend_default_production(monkeypatch):
     """Verify redis queue is default when APP_ENV is production."""
-    with patch.dict(os.environ, {"APP_ENV": "production"}, clear=True):
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("QUEUE_BACKEND", raising=False)
+    with patch("dotenv.load_dotenv"):
         import core.config
         importlib.reload(core.config)
         config = core.config.Settings()


### PR DESCRIPTION
## Summary

Fixes two failing tests caused by `backend/.env` leaking into config reloads during the test suite.

## Changes

- **`test_redis_promotion.py`** — stop clearing the entire environment; unset `QUEUE_BACKEND` and patch `dotenv.load_dotenv` so default queue backend assertions reflect `APP_ENV` only
- **`test_docs_openapi_env.py`** — add `_reload_app()` helper that sets `QUEUE_BACKEND=memory` for development tests, preventing Redis startup during `TestClient` lifespan

## Testing

- Full suite: **301 passed**, 2 skipped, 0 failed (`make tests`)
- Previously failing:
  - `test_queue_backend_default_development`
  - `test_global_exception_handler_masks_errors` (and related OpenAPI env tests when run after redis promotion tests)

## Notes for reviewer

Root cause: local `backend/.env` sets `QUEUE_BACKEND=redis`, which `load_dotenv()` applies on every `importlib.reload(core.config)`. Tests that assumed isolated env vars were inadvertently picking up developer-specific settings. CI was unaffected (no `.env` file); this primarily fixes local/Docker test runs with a mounted `.env`.