### PR TITLE
feat: add Anthropic Claude as supported LLM provider

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -431,6 +431,7 @@ export APP_ENV="development"
 export GEN_AI_KEY="your-key"
 # Or for OpenAI: export OPENAI_API_KEY="your-key" LLM_PROVIDER=openai EMBEDDING_PROVIDER=openai
 # Or for Ollama: export LLM_PROVIDER=ollama EMBEDDING_PROVIDER=ollama
+# Or for Anthropic: export ANTHROPIC_API_KEY="your-key" LLM_PROVIDER=anthropic
 
 uvicorn main:app --reload --port 8000
 ```
@@ -530,7 +531,7 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
 LOG_LEVEL=INFO
 
 # Provider selection (optional — defaults to gemini)
-# LLM_PROVIDER=gemini          # gemini | openai | ollama
+# LLM_PROVIDER=gemini          # gemini | openai | ollama | anthropic
 # EMBEDDING_PROVIDER=gemini    # gemini | openai | ollama
 # See backend/.env.example for all provider options
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,7 +13,7 @@ LOG_USE_UTC=false
 MAX_UPLOAD_SIZE_MB=10
 
 # ── LLM & Embedding Providers ─────────────────────────────────────────────
-# Provider: gemini (default), openai, or ollama
+# Provider: gemini (default), openai, ollama, or anthropic
 # LLM_PROVIDER=gemini
 # LLM_MODEL=                          # optional; provider picks its default
 # EMBEDDING_PROVIDER=gemini
@@ -32,6 +32,10 @@ GEN_AI_KEY=your_google_ai_studio_api_key_here
 
 # Ollama (if LLM_PROVIDER=ollama or EMBEDDING_PROVIDER=ollama)
 # OLLAMA_BASE_URL=http://localhost:11434
+
+# Anthropic (if LLM_PROVIDER=anthropic)
+# ANTHROPIC_API_KEY=your_anthropic_api_key_here
+# ANTHROPIC_BASE_URL=                        # optional; for Anthropic-compatible proxies
 
 # Database (optional - Docker Compose provides these)
 # Only needed if connecting outside Docker

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -24,7 +24,7 @@ else:
 STALE_INGESTION_STATUSES = ["queued", "retrying", "extracting", "chunking", "embedding", "storing"]
 VALID_CHUNKING_STRATEGIES = {"fixed", "paragraph", "semantic"}
 VALID_QUERY_TRANSFORMATION_STRATEGIES = {"rewrite", "expand", "stepback"}
-VALID_LLM_PROVIDERS = {"gemini", "openai", "ollama"}
+VALID_LLM_PROVIDERS = {"gemini", "openai", "ollama", "anthropic"}
 VALID_EMBEDDING_PROVIDERS = {"gemini", "openai", "ollama"}
 
 
@@ -89,6 +89,8 @@ class Settings:
     OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY") or None
     OPENAI_BASE_URL: str | None = os.getenv("OPENAI_BASE_URL") or None
     OLLAMA_BASE_URL: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY") or None
+    ANTHROPIC_BASE_URL: str | None = os.getenv("ANTHROPIC_BASE_URL") or None
 
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
     LOG_USE_UTC: bool = os.getenv("LOG_USE_UTC", "false").lower() in ("1", "true", "yes")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,6 +31,9 @@ google-genai==1.6.0
 # -------- OpenAI --------
 openai==2.31.0
 
+# -------- Anthropic --------
+anthropic==0.104.1
+
 # -------- LangChain / RAG --------
 langchain==1.0.5
 langchain-core==1.0.5

--- a/backend/services/answer_service.py
+++ b/backend/services/answer_service.py
@@ -72,6 +72,8 @@ def _api_key_present() -> bool:
         key = config.GEN_AI_KEY
     elif provider == "openai":
         key = config.OPENAI_API_KEY
+    elif provider == "anthropic":
+        key = config.ANTHROPIC_API_KEY
     else:
         # Ollama typically needs no key.
         return True

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -84,10 +84,16 @@ def get_llm_provider() -> LLMProvider:
         _llm_provider = OllamaLLMProvider()
         logger.info("Using Ollama LLM provider")
 
+    elif name == "anthropic":
+        from services.providers.anthropic import AnthropicLLMProvider
+
+        _llm_provider = AnthropicLLMProvider()
+        logger.info("Using Anthropic LLM provider")
+
     else:
         raise ValueError(
             f"Unknown LLM_PROVIDER={name!r}. "
-            f"Expected one of: gemini, openai, ollama."
+            f"Expected one of: gemini, openai, ollama, anthropic."
         )
 
     return _llm_provider

--- a/backend/services/providers/anthropic.py
+++ b/backend/services/providers/anthropic.py
@@ -1,0 +1,109 @@
+"""Anthropic Claude provider implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncGenerator
+
+import anthropic
+
+from core.config import config
+from services.providers.base import (
+    LLMProvider,
+    ProviderAuthError,
+    ProviderConnectionError,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LLM_MODEL = "claude-sonnet-4-20250514"
+
+
+def _classify_anthropic_error(exc: anthropic.APIError) -> ProviderError:
+    if isinstance(exc, anthropic.APITimeoutError):
+        return ProviderTimeoutError(str(exc))
+    if isinstance(exc, anthropic.APIConnectionError):
+        return ProviderConnectionError(str(exc))
+    if isinstance(exc, anthropic.RateLimitError):
+        return ProviderRateLimitError(str(exc))
+    if isinstance(exc, (anthropic.AuthenticationError, anthropic.PermissionDeniedError)):
+        return ProviderAuthError(str(exc))
+    return ProviderError(str(exc))
+
+
+class AnthropicLLMProvider(LLMProvider):
+    """LLM provider backed by the Anthropic Claude API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self._model = model or config.LLM_MODEL or _DEFAULT_LLM_MODEL
+        self._client = anthropic.AsyncAnthropic(
+            api_key=api_key or config.ANTHROPIC_API_KEY,
+            base_url=base_url or config.ANTHROPIC_BASE_URL,
+            timeout=float(config.LLM_HTTP_TIMEOUT_MS) / 1000.0,
+        )
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        system_instruction: str,
+        temperature: float,
+        max_output_tokens: int,
+        extra_params: dict[str, Any] | None = None,
+    ) -> str:
+        try:
+            create_kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": max_output_tokens,
+                "messages": [{"role": "user", "content": prompt}],
+                "system": system_instruction,
+                "temperature": temperature,
+            }
+            if extra_params:
+                for key in ("top_p", "top_k", "stop_sequences"):
+                    if key in extra_params:
+                        create_kwargs[key] = extra_params[key]
+            response = await self._client.messages.create(**create_kwargs)
+            for block in response.content:
+                if block.type == "text":
+                    return block.text
+            return "No response."
+
+        except anthropic.APIError as exc:
+            raise _classify_anthropic_error(exc) from exc
+
+    async def generate_stream(
+        self,
+        prompt: str,
+        *,
+        system_instruction: str,
+        temperature: float,
+        max_output_tokens: int,
+        extra_params: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[str, None]:
+        try:
+            stream_kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": max_output_tokens,
+                "messages": [{"role": "user", "content": prompt}],
+                "system": system_instruction,
+                "temperature": temperature,
+            }
+            if extra_params:
+                for key in ("top_p", "top_k", "stop_sequences"):
+                    if key in extra_params:
+                        stream_kwargs[key] = extra_params[key]
+            async with self._client.messages.stream(**stream_kwargs) as stream:
+                async for text in stream.text_stream:
+                    yield text
+
+        except anthropic.APIError as exc:
+            raise _classify_anthropic_error(exc) from exc

--- a/backend/services/providers/anthropic.py
+++ b/backend/services/providers/anthropic.py
@@ -19,6 +19,7 @@ from services.providers.base import (
 
 logger = logging.getLogger(__name__)
 
+# See https://docs.anthropic.com/en/docs/about-claude/models
 _DEFAULT_LLM_MODEL = "claude-sonnet-4-20250514"
 
 

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -286,6 +286,29 @@ class TestAnthropicGenerateParsing:
 
         assert "".join(tokens) == "Hello from Claude"
 
+    async def test_missing_api_key_raises_auth_error(self):
+        from unittest.mock import AsyncMock
+        from services.providers.anthropic import AnthropicLLMProvider
+        from services.providers.base import ProviderAuthError
+        import anthropic, httpx
+
+        provider = AnthropicLLMProvider(api_key=None)
+
+        req = httpx.Request("POST", "https://api.anthropic.com")
+        provider._client.messages.create = AsyncMock(
+            side_effect=anthropic.AuthenticationError(
+                "invalid API key", response=httpx.Response(401, request=req), body=None
+            )
+        )
+
+        with pytest.raises(ProviderAuthError):
+            await provider.generate(
+                "hi",
+                system_instruction="be helpful",
+                temperature=0.2,
+                max_output_tokens=64,
+            )
+
 
 # ---------------------------------------------------------------------------
 # Ollama error classification

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -130,6 +130,164 @@ class TestOpenAIErrorClassification:
 
 
 # ---------------------------------------------------------------------------
+# Anthropic error classification
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicErrorClassification:
+    """Verify _classify_anthropic_error maps SDK exceptions correctly."""
+
+    @staticmethod
+    def _make_response(status_code: int):
+        import httpx
+        return httpx.Response(status_code, request=httpx.Request("POST", "https://api.anthropic.com"))
+
+    def test_rate_limit(self):
+        from services.providers.anthropic import _classify_anthropic_error
+        import anthropic
+
+        exc = anthropic.RateLimitError(
+            "rate limited", response=self._make_response(429), body=None
+        )
+        result = _classify_anthropic_error(exc)
+        assert isinstance(result, ProviderRateLimitError)
+
+    def test_auth_error(self):
+        from services.providers.anthropic import _classify_anthropic_error
+        import anthropic
+
+        exc = anthropic.AuthenticationError(
+            "invalid key", response=self._make_response(401), body=None
+        )
+        result = _classify_anthropic_error(exc)
+        assert isinstance(result, ProviderAuthError)
+
+    def test_permission_error(self):
+        from services.providers.anthropic import _classify_anthropic_error
+        import anthropic
+
+        exc = anthropic.PermissionDeniedError(
+            "permission denied", response=self._make_response(403), body=None
+        )
+        result = _classify_anthropic_error(exc)
+        assert isinstance(result, ProviderAuthError)
+
+    def test_timeout(self):
+        from services.providers.anthropic import _classify_anthropic_error
+        import anthropic, httpx
+
+        exc = anthropic.APITimeoutError(request=httpx.Request("POST", "https://api.anthropic.com"))
+        result = _classify_anthropic_error(exc)
+        assert isinstance(result, ProviderTimeoutError)
+
+    def test_connection_error(self):
+        from services.providers.anthropic import _classify_anthropic_error
+        import anthropic, httpx
+
+        exc = anthropic.APIConnectionError(
+            message="connection failed",
+            request=httpx.Request("POST", "https://api.anthropic.com"),
+        )
+        result = _classify_anthropic_error(exc)
+        assert isinstance(result, ProviderConnectionError)
+
+    def test_generic_api_error(self):
+        from services.providers.anthropic import _classify_anthropic_error
+        import anthropic
+
+        exc = anthropic.InternalServerError(
+            "internal error", response=self._make_response(500), body=None
+        )
+        result = _classify_anthropic_error(exc)
+        assert isinstance(result, ProviderError)
+        assert not isinstance(result, ProviderAuthError)
+        assert not isinstance(result, ProviderRateLimitError)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic generate() / generate_stream() response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicGenerateParsing:
+    """Verify AnthropicLLMProvider.generate() extracts content[0].text."""
+
+    async def test_returns_text_content(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.anthropic import AnthropicLLMProvider
+
+        provider = AnthropicLLMProvider(api_key="test-key")
+
+        fake_text_block = MagicMock()
+        fake_text_block.type = "text"
+        fake_text_block.text = "Hello from Claude"
+
+        fake_response = MagicMock()
+        fake_response.content = [fake_text_block]
+        provider._client.messages.create = AsyncMock(return_value=fake_response)
+
+        result = await provider.generate(
+            "hi",
+            system_instruction="be helpful",
+            temperature=0.2,
+            max_output_tokens=64,
+        )
+
+        assert result == "Hello from Claude"
+
+    async def test_skips_non_text_blocks_and_falls_back(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.anthropic import AnthropicLLMProvider
+
+        provider = AnthropicLLMProvider(api_key="test-key")
+
+        tool_use_block = MagicMock()
+        tool_use_block.type = "tool_use"
+        tool_use_block.name = "get_weather"
+
+        fake_response = MagicMock()
+        fake_response.content = [tool_use_block]
+        provider._client.messages.create = AsyncMock(return_value=fake_response)
+
+        result = await provider.generate(
+            "hi",
+            system_instruction="be helpful",
+            temperature=0.2,
+            max_output_tokens=64,
+        )
+
+        assert result == "No response."
+
+    async def test_streaming_yields_text(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.anthropic import AnthropicLLMProvider
+
+        provider = AnthropicLLMProvider(api_key="test-key")
+
+        fake_stream = MagicMock()
+        fake_text_stream = AsyncMock()
+        fake_text_stream.__aiter__.return_value = iter(["Hello", " ", "from", " ", "Claude"])
+        type(fake_stream).text_stream = fake_text_stream
+
+        fake_stream_manager = MagicMock()
+        fake_stream_manager.__aenter__.return_value = fake_stream
+        fake_stream_manager.__aexit__.return_value = None
+
+        provider._client.messages.stream = MagicMock(return_value=fake_stream_manager)
+
+        tokens = []
+        async for token in provider.generate_stream(
+            "hi",
+            system_instruction="be helpful",
+            temperature=0.2,
+            max_output_tokens=64,
+        ):
+            tokens.append(token)
+
+        assert "".join(tokens) == "Hello from Claude"
+
+
+# ---------------------------------------------------------------------------
 # Ollama error classification
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_providers_factory.py
+++ b/backend/tests/test_providers_factory.py
@@ -96,6 +96,12 @@ class TestGetLLMProvider:
         assert isinstance(provider, LLMProvider)
         assert type(provider).__name__ == "OllamaLLMProvider"
 
+    def test_anthropic_selection(self, monkeypatch):
+        monkeypatch.setattr(providers_mod.config, "LLM_PROVIDER", "anthropic")
+        provider = providers_mod.get_llm_provider()
+        assert isinstance(provider, LLMProvider)
+        assert type(provider).__name__ == "AnthropicLLMProvider"
+
     def test_singleton_caching(self, monkeypatch):
         monkeypatch.setattr(providers_mod.config, "LLM_PROVIDER", "ollama")
         p1 = providers_mod.get_llm_provider()

--- a/backend/tests/test_providers_factory.py
+++ b/backend/tests/test_providers_factory.py
@@ -102,6 +102,16 @@ class TestGetLLMProvider:
         assert isinstance(provider, LLMProvider)
         assert type(provider).__name__ == "AnthropicLLMProvider"
 
+    def test_anthropic_llm_doesnt_affect_embedding(self, monkeypatch):
+        monkeypatch.setattr(providers_mod.config, "LLM_PROVIDER", "anthropic")
+        monkeypatch.setattr(providers_mod.config, "EMBEDDING_PROVIDER", "gemini")
+        llm = providers_mod.get_llm_provider()
+        emb = providers_mod.get_embedding_provider()
+        assert isinstance(llm, LLMProvider)
+        assert isinstance(emb, EmbeddingProvider)
+        assert type(llm).__name__ == "AnthropicLLMProvider"
+        assert llm is not emb
+
     def test_singleton_caching(self, monkeypatch):
         monkeypatch.setattr(providers_mod.config, "LLM_PROVIDER", "ollama")
         p1 = providers_mod.get_llm_provider()


### PR DESCRIPTION
## What does this PR do?

Adds Anthropic Claude as a supported LLM provider, following the existing provider pattern (`openai.py`, `gemini.py`, `ollama.py`).

### Changes

- **`backend/services/providers/anthropic.py`** (new) — `AnthropicLLMProvider` with `generate()`, `generate_stream()`, and SDK error classification
- **`backend/services/providers/__init__.py`** — Added `anthropic` case to `get_llm_provider()` factory
- **`backend/core/config.py`** — Added `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `VALID_LLM_PROVIDERS`
- **`backend/services/answer_service.py`** — Added `anthropic` to `_api_key_present()` check
- **`backend/requirements.txt`** — Added `anthropic==0.104.1`
- **`backend/.env.example`** — Documented Anthropic env vars
- **`DEVELOPMENT.md`** — Updated provider list and example commands
- **`backend/tests/test_providers.py`** — 10 tests: error classification + generate/stream parsing + missing API key
- **`backend/tests/test_providers_factory.py`** — Factory selection + mixed-provider independence tests

### Design

- Embeddings are **not** included — Anthropic only provides LLM APIs
- Uses `AsyncAnthropic` SDK with `client.messages.create()` (non-streaming) and `client.messages.stream()` (streaming via SSE)
- Error mapping follows OpenAI pattern — class-based `isinstance` checks on SDK exceptions

## How was it tested?

- Ran `pytest tests/test_providers.py tests/test_providers_factory.py -v` — 48 passed, 2 skipped (OpenAI factory tests need API key)
- Tested locally with FastAPI `/docs`
- Checked existing functionality still works

> **Note:** Requires `docker compose build` (or `make build`) after pulling due to the new `anthropic` dependency in `requirements.txt`.