### PR TITLE
Add footer to shared layout for consistent rendering

### DIFF
--- a/frontend-demo/app/about/page.tsx
+++ b/frontend-demo/app/about/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { Kicker } from "@/app/components/Kicker";
-import Footer from "../components/home/Footer";
 
 export default function AboutPage() {
   return (
@@ -13,7 +12,12 @@ export default function AboutPage() {
             A developer-focused RAG engine you can deploy as a service.
           </h1>
           <p className="text-muted text-lg leading-relaxed mb-6">
-            Most RAG implementations today are fragile, vendor-locked, or require significant plumbing to productionize. ChatVector solves this by providing a clean, extensible backend foundation for document intelligence. It handles the full document Q&A lifecycle—from ingestion and semantic chunking to vector storage and cited response generation—all through a clean HTTP API.
+            Most RAG implementations today are fragile, vendor-locked, or
+            require significant plumbing to productionize. ChatVector solves
+            this by providing a clean, extensible backend foundation for
+            document intelligence. It handles the full document Q&A
+            lifecycle—from ingestion and semantic chunking to vector storage and
+            cited response generation—all through a clean HTTP API.
           </p>
         </section>
 
@@ -66,7 +70,9 @@ export default function AboutPage() {
               <thead>
                 <tr className="border-b border-border bg-background/30 text-foreground">
                   <th className="px-5 py-4 font-bold">Aspect</th>
-                  <th className="px-5 py-4 font-bold text-accent">ChatVector</th>
+                  <th className="px-5 py-4 font-bold text-accent">
+                    ChatVector
+                  </th>
                   <th className="px-5 py-4 font-bold">General Framework</th>
                 </tr>
               </thead>
@@ -131,7 +137,6 @@ export default function AboutPage() {
           </Link>
         </div>
       </div>
-      <Footer />
     </div>
   );
 }

--- a/frontend-demo/app/components/home/Footer.tsx
+++ b/frontend-demo/app/components/home/Footer.tsx
@@ -1,4 +1,6 @@
+"use client";
 import { GITHUB_REPO } from "../../lib/constants";
+import { usePathname } from "next/navigation";
 
 const FOOTER_LINKS: { label: string; href: string; external?: boolean }[] = [
   { label: "GitHub", href: GITHUB_REPO, external: true },
@@ -13,11 +15,15 @@ const FOOTER_LINKS: { label: string; href: string; external?: boolean }[] = [
 ];
 
 export default function Footer() {
+  const pathname = usePathname();
+  if (pathname.startsWith("/chat")) {
+    return null;
+  }
   return (
     <footer className="border-t border-border px-8 py-10">
       <div className="mx-auto flex max-w-[1100px] flex-wrap items-center justify-between gap-6">
         <div className="font-mono text-[1.2rem] font-bold text-accent">
-        <span className="bg-gradient-to-r from-accent to-blue bg-clip-text text-transparent">
+          <span className="bg-gradient-to-r from-accent to-blue bg-clip-text text-transparent">
             ChatVector
           </span>
         </div>

--- a/frontend-demo/app/layout.tsx
+++ b/frontend-demo/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Navigation from "./components/Navigation";
+import Footer from "./components/home/Footer";
 
 export const metadata: Metadata = {
   title: "ChatVector",
@@ -26,6 +27,7 @@ export default function RootLayout({
       <body className="flex min-h-screen flex-col antialiased">
         <Navigation />
         <main className="flex min-h-0 flex-1 flex-col">{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/frontend-demo/app/page.tsx
+++ b/frontend-demo/app/page.tsx
@@ -2,7 +2,6 @@ import Hero from "./components/home/Hero";
 import WhatIs from "./components/home/WhatIs";
 import Features from "./components/home/Features";
 import Developers from "./components/home/Developers";
-import Footer from "./components/home/Footer";
 
 export default function Home() {
   return (
@@ -11,7 +10,6 @@ export default function Home() {
       <WhatIs />
       <Features />
       <Developers />
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
- Added the shared Footer component inside app/layout.tsx so it renders consistently across the application.
- Removed direct footer rendering from individual pages/layouts to avoid duplication.
- Excluded the footer from /chat routes by using the usePathname() hook inside the Footer component and conditionally returning null.