### PR TITLE
feat: add Voyage AI as supported embedding provider

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,11 +65,13 @@ An abstract base class defines the contract for each service type:
 - `EmbeddingProvider` — `async def embed(texts) -> list[list[float]]`
 - `LLMProvider` — `async def generate(prompt, ...) -> str`
 
-Three implementations:
+Multiple implementations:
 
 - `GeminiEmbeddingProvider` / `GeminiLLMProvider` (default)
 - `OpenAIEmbeddingProvider` / `OpenAILLMProvider`
 - `OllamaEmbeddingProvider` / `OllamaLLMProvider`
+- `VoyageEmbeddingProvider` (embedding-only)
+- `AnthropicLLMProvider` (LLM-only)
 
 Selected via environment variables (`LLM_PROVIDER`, `EMBEDDING_PROVIDER`) through factory functions in:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -532,7 +532,7 @@ LOG_LEVEL=INFO
 
 # Provider selection (optional — defaults to gemini)
 # LLM_PROVIDER=gemini          # gemini | openai | ollama | anthropic
-# EMBEDDING_PROVIDER=gemini    # gemini | openai | ollama
+# EMBEDDING_PROVIDER=gemini    # gemini | openai | ollama | voyage
 # See backend/.env.example for all provider options
 ```
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,6 +37,9 @@ GEN_AI_KEY=your_google_ai_studio_api_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # ANTHROPIC_BASE_URL=                        # optional; for Anthropic-compatible proxies
 
+# Voyage AI (if EMBEDDING_PROVIDER=voyage)
+# VOYAGE_API_KEY=your_voyage_api_key_here
+
 # Database (optional - Docker Compose provides these)
 # Only needed if connecting outside Docker
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -25,7 +25,7 @@ STALE_INGESTION_STATUSES = ["queued", "retrying", "extracting", "chunking", "emb
 VALID_CHUNKING_STRATEGIES = {"fixed", "paragraph", "semantic"}
 VALID_QUERY_TRANSFORMATION_STRATEGIES = {"rewrite", "expand", "stepback"}
 VALID_LLM_PROVIDERS = {"gemini", "openai", "ollama", "anthropic"}
-VALID_EMBEDDING_PROVIDERS = {"gemini", "openai", "ollama"}
+VALID_EMBEDDING_PROVIDERS = {"gemini", "openai", "ollama", "voyage"}
 
 
 def _get_chunking_strategy() -> str:
@@ -91,6 +91,7 @@ class Settings:
     OLLAMA_BASE_URL: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY") or None
     ANTHROPIC_BASE_URL: str | None = os.getenv("ANTHROPIC_BASE_URL") or None
+    VOYAGE_API_KEY: str | None = os.getenv("VOYAGE_API_KEY") or None
 
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
     LOG_USE_UTC: bool = os.getenv("LOG_USE_UTC", "false").lower() in ("1", "true", "yes")

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -48,10 +48,16 @@ def get_embedding_provider() -> EmbeddingProvider:
         _embedding_provider = OllamaEmbeddingProvider()
         logger.info("Using Ollama embedding provider")
 
+    elif name == "voyage":
+        from services.providers.voyage import VoyageEmbeddingProvider
+
+        _embedding_provider = VoyageEmbeddingProvider()
+        logger.info("Using Voyage AI embedding provider")
+
     else:
         raise ValueError(
             f"Unknown EMBEDDING_PROVIDER={name!r}. "
-            f"Expected one of: gemini, openai, ollama."
+            f"Expected one of: gemini, openai, ollama, voyage."
         )
 
     return _embedding_provider

--- a/backend/services/providers/base.py
+++ b/backend/services/providers/base.py
@@ -60,7 +60,7 @@ KNOWN_EMBEDDING_DIMS: dict[str, int] = {
     # Voyage AI
     "voyage-3-large": 1024,
     "voyage-3": 1024,
-    "voyage-3-lite": 1024,
+    "voyage-3-lite": 512,
     "voyage-code-2": 1536,
     "voyage-law-2": 1024,
     "voyage-2": 1024,

--- a/backend/services/providers/base.py
+++ b/backend/services/providers/base.py
@@ -57,6 +57,13 @@ KNOWN_EMBEDDING_DIMS: dict[str, int] = {
     "mxbai-embed-large": 1024,
     "all-minilm": 384,
     "snowflake-arctic-embed": 1024,
+    # Voyage AI
+    "voyage-3-large": 1024,
+    "voyage-3": 1024,
+    "voyage-3-lite": 1024,
+    "voyage-code-2": 1536,
+    "voyage-law-2": 1024,
+    "voyage-2": 1024,
 }
 
 # Default embedding model per provider (must match the defaults in each
@@ -65,6 +72,7 @@ _DEFAULT_EMBEDDING_MODELS: dict[str, str] = {
     "gemini": "models/gemini-embedding-001",
     "openai": "text-embedding-3-small",
     "ollama": "nomic-embed-text",
+    "voyage": "voyage-3-large",
 }
 
 

--- a/backend/services/providers/voyage.py
+++ b/backend/services/providers/voyage.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import httpx
 

--- a/backend/services/providers/voyage.py
+++ b/backend/services/providers/voyage.py
@@ -1,0 +1,88 @@
+"""Voyage AI embedding provider implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from core.config import config
+from services.providers.base import (
+    EmbeddingProvider,
+    ProviderAuthError,
+    ProviderConnectionError,
+    ProviderError,
+    ProviderRateLimitError,
+    ProviderTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_EMBEDDING_MODEL = "voyage-3-large"
+_BATCH_SIZE = 128
+
+
+def _classify_http_error(exc: httpx.HTTPStatusError) -> ProviderError:
+    code = exc.response.status_code
+    if code == 429:
+        return ProviderRateLimitError(str(exc))
+    if code in (401, 403):
+        return ProviderAuthError(str(exc))
+    return ProviderError(str(exc))
+
+
+def _classify_network_error(
+    exc: httpx.TimeoutException | httpx.ConnectError | httpx.NetworkError,
+) -> ProviderTimeoutError | ProviderConnectionError:
+    if isinstance(exc, httpx.TimeoutException):
+        return ProviderTimeoutError(str(exc))
+    return ProviderConnectionError(str(exc))
+
+
+class VoyageEmbeddingProvider(EmbeddingProvider):
+    """Embedding provider backed by the Voyage AI REST API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self._model = model or config.EMBEDDING_MODEL or _DEFAULT_EMBEDDING_MODEL
+        self._api_key = api_key or config.VOYAGE_API_KEY
+        self._base_url = (base_url or "https://api.voyageai.com").rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=float(config.EMBEDDING_HTTP_TIMEOUT_SEC),
+        )
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        if not self._api_key:
+            raise ProviderAuthError("VOYAGE_API_KEY is not configured.")
+
+        all_embeddings: list[list[float]] = []
+
+        for batch_start in range(0, len(texts), _BATCH_SIZE):
+            batch = texts[batch_start : batch_start + _BATCH_SIZE]
+            try:
+                response = await self._client.post(
+                    "/v1/embeddings",
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    json={"input": batch, "model": self._model},
+                )
+                response.raise_for_status()
+                data = response.json()
+                embeddings = [item["embedding"] for item in data["data"]]
+                all_embeddings.extend(embeddings)
+
+            except httpx.HTTPStatusError as exc:
+                raise _classify_http_error(exc) from exc
+            except (
+                httpx.TimeoutException,
+                httpx.ConnectError,
+                httpx.NetworkError,
+            ) as exc:
+                raise _classify_network_error(exc) from exc
+
+        return all_embeddings

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -590,7 +590,7 @@ class TestOllamaGenerateParsing:
 
 
 class TestVoyageEmbedParsing:
-    """Verify VoyageEmbeddingProvider.embed() extracts response['embeddings']."""
+    """Verify VoyageEmbeddingProvider.embed() extracts data[i]["embedding"]."""
 
     async def test_returns_embeddings_list(self):
         from unittest.mock import AsyncMock, MagicMock
@@ -615,10 +615,11 @@ class TestVoyageEmbedParsing:
 
         assert result == [[0.1, 0.2], [0.3, 0.4]]
 
-    async def test_missing_api_key_raises_auth_error(self):
-        from services.providers.voyage import VoyageEmbeddingProvider
+    async def test_missing_api_key_raises_auth_error(self, monkeypatch):
+        from services.providers.voyage import VoyageEmbeddingProvider, config
         from services.providers.base import ProviderAuthError
 
+        monkeypatch.setattr(config, "VOYAGE_API_KEY", None)
         provider = VoyageEmbeddingProvider(api_key=None)
 
         with pytest.raises(ProviderAuthError, match="VOYAGE_API_KEY is not configured"):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -584,6 +584,136 @@ class TestOllamaGenerateParsing:
         assert result == "No response."
 
 
+# ---------------------------------------------------------------------------
+# Voyage AI embed() response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestVoyageEmbedParsing:
+    """Verify VoyageEmbeddingProvider.embed() extracts response['embeddings']."""
+
+    async def test_returns_embeddings_list(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.voyage import VoyageEmbeddingProvider
+
+        provider = VoyageEmbeddingProvider(api_key="test-key")
+
+        fake_response = MagicMock()
+        fake_response.raise_for_status = MagicMock()
+        fake_response.json = MagicMock(
+            return_value={
+                "object": "list",
+                "data": [
+                    {"object": "embedding", "embedding": [0.1, 0.2], "index": 0},
+                    {"object": "embedding", "embedding": [0.3, 0.4], "index": 1},
+                ],
+            }
+        )
+        provider._client.post = AsyncMock(return_value=fake_response)
+
+        result = await provider.embed(["a", "b"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+    async def test_missing_api_key_raises_auth_error(self):
+        from services.providers.voyage import VoyageEmbeddingProvider
+        from services.providers.base import ProviderAuthError
+
+        provider = VoyageEmbeddingProvider(api_key=None)
+
+        with pytest.raises(ProviderAuthError, match="VOYAGE_API_KEY is not configured"):
+            await provider.embed(["test"])
+
+    async def test_batches_large_inputs(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from services.providers.voyage import VoyageEmbeddingProvider
+
+        provider = VoyageEmbeddingProvider(api_key="test-key")
+        BATCH = 128
+        total = BATCH * 2 + 1
+
+        call_count = 0
+
+        async def fake_post(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            batch = kwargs.get("json", {}).get("input", [])
+            batch_size = len(batch)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            dim = 3
+            embeddings = [
+                {"object": "embedding", "embedding": [float(call_count)] * dim, "index": j}
+                for j in range(batch_size)
+            ]
+            resp.json = MagicMock(return_value={"object": "list", "data": embeddings})
+            return resp
+
+        provider._client.post = fake_post
+
+        texts = ["t"] * total
+        result = await provider.embed(texts)
+
+        assert call_count == 3
+        assert len(result) == total
+        assert result[0] == [1.0, 1.0, 1.0]
+        assert result[BATCH - 1] == [1.0, 1.0, 1.0]
+        assert result[BATCH] == [2.0, 2.0, 2.0]
+        assert result[-1] == [3.0, 3.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# Voyage AI error classification
+# ---------------------------------------------------------------------------
+
+
+class TestVoyageErrorClassification:
+    """Verify Voyage error mappers classify httpx errors correctly."""
+
+    def test_http_429_is_rate_limit(self):
+        import httpx
+        from services.providers.voyage import _classify_http_error, _classify_network_error
+
+        response = httpx.Response(429, request=httpx.Request("POST", "http://test"))
+        exc = httpx.HTTPStatusError("rate limited", request=response.request, response=response)
+        result = _classify_http_error(exc)
+        assert isinstance(result, ProviderRateLimitError)
+
+    def test_http_401_is_auth(self):
+        import httpx
+        from services.providers.voyage import _classify_http_error
+
+        response = httpx.Response(401, request=httpx.Request("POST", "http://test"))
+        exc = httpx.HTTPStatusError("unauthorized", request=response.request, response=response)
+        result = _classify_http_error(exc)
+        assert isinstance(result, ProviderAuthError)
+
+    def test_http_500_is_provider_error(self):
+        import httpx
+        from services.providers.voyage import _classify_http_error
+
+        response = httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        exc = httpx.HTTPStatusError("server error", request=response.request, response=response)
+        result = _classify_http_error(exc)
+        assert isinstance(result, ProviderError)
+
+    def test_timeout_is_provider_timeout(self):
+        import httpx
+        from services.providers.voyage import _classify_network_error
+
+        exc = httpx.ReadTimeout("timed out")
+        result = _classify_network_error(exc)
+        assert isinstance(result, ProviderTimeoutError)
+
+    def test_connect_error_is_connection(self):
+        import httpx
+        from services.providers.voyage import _classify_network_error
+
+        exc = httpx.ConnectError("refused")
+        result = _classify_network_error(exc)
+        assert isinstance(result, ProviderConnectionError)
+
+
 class TestEmbeddingDimResolution:
     """embedding_dim must not silently default for unknown models."""
 

--- a/backend/tests/test_providers_factory.py
+++ b/backend/tests/test_providers_factory.py
@@ -58,6 +58,18 @@ class TestGetEmbeddingProvider:
         assert isinstance(provider, EmbeddingProvider)
         assert type(provider).__name__ == "OllamaEmbeddingProvider"
 
+    def test_voyage_selection(self, monkeypatch):
+        monkeypatch.setattr(providers_mod.config, "EMBEDDING_PROVIDER", "voyage")
+        provider = providers_mod.get_embedding_provider()
+        assert isinstance(provider, EmbeddingProvider)
+        assert type(provider).__name__ == "VoyageEmbeddingProvider"
+
+    def test_voyage_singleton(self, monkeypatch):
+        monkeypatch.setattr(providers_mod.config, "EMBEDDING_PROVIDER", "voyage")
+        p1 = providers_mod.get_embedding_provider()
+        p2 = providers_mod.get_embedding_provider()
+        assert p1 is p2
+
     def test_singleton_caching(self, monkeypatch):
         monkeypatch.setattr(providers_mod.config, "EMBEDDING_PROVIDER", "ollama")
         p1 = providers_mod.get_embedding_provider()


### PR DESCRIPTION
## What does this PR do?

Adds Voyage AI as a supported embedding provider, following the existing httpx-based pattern (like `ollama.py`). Includes domain-tuned models for legal (`voyage-law-2`) and code (`voyage-code-2`).

### Changes

- **`backend/services/providers/voyage.py`** (new) — `VoyageEmbeddingProvider` with httpx, batch size 128, API key validation
- **`backend/services/providers/base.py`** — Added Voyage models to `KNOWN_EMBEDDING_DIMS` + `_DEFAULT_EMBEDDING_MODELS`
- **`backend/services/providers/__init__.py`** — Added `voyage` case to `get_embedding_provider()` factory
- **`backend/core/config.py`** — Added `VOYAGE_API_KEY`, `VALID_EMBEDDING_PROVIDERS`
- **`backend/.env.example`** — Documented Voyage env vars
- **`ARCHITECTURE.md`** — Updated provider list
- **`DEVELOPMENT.md`** — Added voyage to provider comment
- **`backend/tests/test_providers.py`** — 8 tests: embed parsing, error classification, batching, missing API key
- **`backend/tests/test_providers_factory.py`** — 2 tests: factory selection + singleton

### Design

- Uses httpx (no SDK dependency) — matches Ollama pattern, native async
- Batch size 128 for universal compatibility across all Voyage models
- Missing API key raises `ProviderAuthError` with a clear message
- Error mapping via HTTP status codes (same as Ollama)

## How was it tested?
- Ran `pytest tests/test_providers.py tests/test_providers_factory.py -v` — 58 passed, 2 skipped (OpenAI factory tests need API key)

> **Note:** No new dependencies added — httpx is already installed.