### PR TITLE
docs: rewrite frontend demo README

### DIFF
--- a/frontend-demo/README.md
+++ b/frontend-demo/README.md
@@ -1,44 +1,46 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ChatVector Frontend Demo
 
-## Getting Started
+This folder contains the ChatVector frontend demo. It is a Next.js app for trying the local ChatVector flow: upload documents, watch ingestion progress, and chat with retrieved context and citations. It is a contributor demo, not a standalone product.
 
-First, run the development server:
+## Prerequisites
+
+- Node.js 18+
+- ChatVector backend running at `http://localhost:8000` (see the root [README setup instructions](../README.md))
+
+## Setup
+
+```bash
+npm install
+cp .env.example .env.local
+```
+
+Set the backend URL in `.env.local`:
+
+```env
+NEXT_PUBLIC_API_URL=http://localhost:8000
+```
+
+## Run
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open http://localhost:3000.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+From the repository root, you can also run `make dev` to start the backend stack and frontend dev server together.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Verify changes
 
-## Environment Variables
+Run these from `frontend-demo/` before opening a PR:
 
-Copy `.env.example` to `.env.local` and adjust values as needed:
+```bash
+npm run build
+npm run lint
+```
 
-| Variable | Description | Default |
-|---|---|---|
-| `NEXT_PUBLIC_API_URL` | Base URL of the ChatVector backend API | `http://localhost:8000` |
+## Where to go next
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- [DEVELOPMENT.md](../DEVELOPMENT.md) — local development setup, including the Frontend section
+- [FRONTEND.md](./FRONTEND.md) — design tokens and UI conventions
+- [Issues labeled `frontend-demo`](https://github.com/chatvector-ai/chatvector-ai/issues?q=is%3Aissue%20is%3Aopen%20label%3Afrontend-demo) — frontend demo work items


### PR DESCRIPTION
## Summary
- replace the stock Next.js README in `frontend-demo/` with a concise ChatVector demo guide
- document prerequisites, setup, run, verification, and next-step links

Closes #309

@admaloch

## Checks
- `npm install`
- `npm run build`
- `npm run lint`
- verified relative paths to `../DEVELOPMENT.md`, `./FRONTEND.md`, `../README.md`, and `.env.example`