### PR TITLE
feat: show document processing duration on ingestion completion

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -89,6 +89,7 @@ export default function ChatPage() {
                     status: attachment.status,
                     stage: poll.stage,
                     chunks: poll.chunks,
+                    processingTime: poll.processingTime,
                   }
                 : null
             }

--- a/frontend-demo/app/components/AttachmentChip.tsx
+++ b/frontend-demo/app/components/AttachmentChip.tsx
@@ -9,6 +9,7 @@ type Props = {
   stage?: string;
   chunks?: { total: number; processed: number };
   awaitingProcessing?: boolean;
+  processingTime?: string;
   onRemove: () => void;
 };
 
@@ -54,6 +55,7 @@ export default function AttachmentChip({
   stage,
   chunks,
   awaitingProcessing = false,
+  processingTime,
   onRemove,
 }: Props) {
   const label = chipLabel(
@@ -74,6 +76,11 @@ export default function AttachmentChip({
       >
         {label}
       </span>
+      {status === "ready" && processingTime && (
+        <span className="shrink-0 text-[10px] text-subtle" title={`Processed in ${processingTime}`}>
+          {processingTime}
+        </span>
+      )}
       <button
         type="button"
         onClick={onRemove}

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -15,6 +15,7 @@ export type UploadModalAttachment = {
   status: "processing" | "ready" | "failed";
   stage?: string;
   chunks?: { total: number; processed: number };
+  processingTime?: string;
 };
 
 type Props = {
@@ -307,6 +308,9 @@ export default function UploadModal({
                       <br />
                       Successful
                     </p>
+                    {attachment?.processingTime && (
+                      <p className="text-xs text-muted">Processed in {attachment.processingTime}</p>
+                    )}
                   </>
                 ) : (
                   <>

--- a/frontend-demo/app/components/chat/ChatInput.tsx
+++ b/frontend-demo/app/components/chat/ChatInput.tsx
@@ -60,6 +60,7 @@ export default function ChatInput({
             stage={poll.stage}
             chunks={poll.chunks}
             awaitingProcessing={poll.awaitingProcessing}
+            processingTime={poll.processingTime}
             onRemove={() => void handleRemoveAttachment()}
           />
         </div>

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -118,6 +118,8 @@ export type DocumentStatusPayload = {
   stage?: string;
   error?: { stage?: string };
   chunks?: { total: number; processed: number } | null;
+  created_at?: string | null;
+  updated_at?: string | null;
 };
 
 function parseChunks(raw: unknown): { total: number; processed: number } | undefined {
@@ -146,11 +148,15 @@ export async function getDocumentStatus(
     errorRaw != null && typeof errorRaw === "object"
       ? { stage: (errorRaw as Record<string, unknown>).stage as string | undefined }
       : undefined;
+  const createdAt = data?.created_at as string | null | undefined;
+  const updatedAt = data?.updated_at as string | null | undefined;
   return {
     status,
     ...(stage !== undefined ? { stage } : {}),
     ...(error !== undefined ? { error } : {}),
     ...(chunks !== undefined ? { chunks } : {}),
+    ...(createdAt !== undefined ? { created_at: createdAt } : {}),
+    ...(updatedAt !== undefined ? { updated_at: updatedAt } : {}),
   };
 }
 

--- a/frontend-demo/app/lib/hooks/useChat.ts
+++ b/frontend-demo/app/lib/hooks/useChat.ts
@@ -83,7 +83,7 @@ export function useChat(sessionId: string | null) {
         text: `Document "${name}" is ready. You can ask questions about it.`,
       },
     ]);
-  }, [poll.status, poll.chunks, attachment]);
+  }, [poll.status, poll.chunks, poll.processingTime, attachment]);
 
   useEffect(() => {
     if (poll.status !== "failed" || !attachment || attachment.status !== "processing") {

--- a/frontend-demo/app/lib/hooks/useChat.ts
+++ b/frontend-demo/app/lib/hooks/useChat.ts
@@ -72,6 +72,7 @@ export function useChat(sessionId: string | null) {
         status: "ready",
         stage: "completed",
         chunks: poll.chunks,
+        processingTime: poll.processingTime,
       };
     });
     setMessages((prev) => [

--- a/frontend-demo/app/lib/hooks/useDocumentPolling.ts
+++ b/frontend-demo/app/lib/hooks/useDocumentPolling.ts
@@ -16,7 +16,15 @@ function mapApiStatusToUi(apiStatus: string): PolledDocumentStatus {
   return "processing";
 }
 
-/** Returns all pipeline stages that come strictly before `currentStage`. */
+/** Format a duration in milliseconds to a human-readable string. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+}
 function stagesBefore(currentStage: string): string[] {
   const idx = PIPELINE_STAGES.indexOf(currentStage as never);
   if (idx <= 0) return [];
@@ -65,6 +73,7 @@ export function useDocumentPolling(
   completedStages: string[];
   chunks: { total: number; processed: number } | undefined;
   awaitingProcessing: boolean;
+  processingTime: string | undefined;
 } {
   const [polledUiStatus, setPolledUiStatus] = useState<
     PolledDocumentStatus | undefined
@@ -75,6 +84,7 @@ export function useDocumentPolling(
     { total: number; processed: number } | undefined
   >(undefined);
   const [awaitingProcessing, setAwaitingProcessing] = useState(false);
+  const [processingTime, setProcessingTime] = useState<string | undefined>(undefined);
 
   // A toggle for environments/situations where SSE fails
   const [useFallbackPolling, setUseFallbackPolling] = useState(false);
@@ -94,6 +104,7 @@ export function useDocumentPolling(
       setChunks(undefined);
       setAwaitingProcessing(false);
       setUseFallbackPolling(false);
+      setProcessingTime(undefined);
     }
   }, [docKey]);
 
@@ -138,6 +149,15 @@ export function useDocumentPolling(
 
           const ui = mapApiStatusToUi(payload.status);
           setPolledUiStatus(ui);
+
+          // Compute processing duration when ingestion completes
+          if (ui === "ready" && payload.created_at && payload.updated_at) {
+            const created = new Date(payload.created_at).getTime();
+            const updated = new Date(payload.updated_at).getTime();
+            if (!isNaN(created) && !isNaN(updated) && updated > created) {
+              setProcessingTime(formatDuration(updated - created));
+            }
+          }
 
           if (payload.status === "completed" || payload.status === "failed") {
             eventSource?.close();
@@ -195,6 +215,15 @@ export function useDocumentPolling(
 
           const ui = mapApiStatusToUi(payload.status);
           setPolledUiStatus(ui);
+
+          // Compute processing duration when ingestion completes
+          if (ui === "ready" && payload.created_at && payload.updated_at) {
+            const created = new Date(payload.created_at).getTime();
+            const updated = new Date(payload.updated_at).getTime();
+            if (!isNaN(created) && !isNaN(updated) && updated > created) {
+              setProcessingTime(formatDuration(updated - created));
+            }
+          }
           
           if (payload.status === "completed" || payload.status === "failed") {
               if (interval) clearInterval(interval);
@@ -232,5 +261,6 @@ export function useDocumentPolling(
     completedStages,
     chunks,
     awaitingProcessing: enabled && awaitingProcessing,
+    processingTime,
   };
 }


### PR DESCRIPTION
## Problem

The backend returns `created_at` and `updated_at` timestamps on every document status response, but the frontend doesn't use them. Users have no feedback on how long their document ingestion took.

## Fix

- **`frontend-demo/app/lib/api.ts`**: Added `created_at` and `updated_at` fields to `DocumentStatusPayload` type and parse them from the API response in `getDocumentStatus()`.

- **`frontend-demo/app/lib/hooks/useDocumentPolling.ts`**: Added `formatDuration()` helper and compute processing duration when status transitions to `"ready"`. Exposes `processingTime: string | undefined` in the hook return value.

- **`frontend-demo/app/components/UploadModal.tsx`**: Display `"Processed in Xs"` below the "Upload Successful" message when the processing time is available.

- **`frontend-demo/app/components/AttachmentChip.tsx`**: Show a small processing time badge next to the document name when status is `"ready"`.

- **`frontend-demo/app/lib/hooks/useChat.ts`**: Propagate `processingTime` through the attachment state.

- **`frontend-demo/app/components/chat/ChatInput.tsx`**: Pass `processingTime` from the poll hook to `AttachmentChip`.

## Edge Cases

- If either `created_at` or `updated_at` is missing or unparseable, the processing time is simply not displayed (graceful degradation).
- No display while ingestion is still in progress — only shown after completion.

## Test Plan

- [x] Upload a document and verify the processing duration appears on completion
- [ ] Duration formats correctly (e.g., "2.3s", "1m 12s")
- [ ] No display if timestamps are missing
- [ ] No display while processing
- [ ] Processing time badge appears in AttachmentChip when document is ready

Closes #313
