### PR TITLE
fix: show embedding chunk progress during ingestion

### DIFF
--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Check, Loader2, AlertCircle } from "lucide-react";
+import {
+  formatChunkProgress,
+  shouldShowChunkProgress,
+} from "../lib/chunkProgress";
 import { PIPELINE_STAGES, PIPELINE_STAGE_LABELS } from "../lib/stageLabels";
 
 /** ms between each incremental stage completion when fast-forwarding. */
@@ -114,8 +118,9 @@ function StageRow({
   isLast: boolean;
   chunks?: { total: number; processed: number };
 }) {
-  const showChunks =
-    stageKey === "embedding" && state === "active" && chunks?.total;
+  const showChunks = shouldShowChunkProgress({ stageKey, state, chunks });
+  const chunkProgressLabel =
+    showChunks && chunks ? formatChunkProgress(chunks) : null;
 
   return (
     <li className="flex items-start gap-3">
@@ -172,9 +177,9 @@ function StageRow({
         >
           {label}
         </span>
-        {showChunks && (
+        {chunkProgressLabel && (
           <p className="absolute top-full -mt-3 text-xs text-muted">
-            {chunks!.total} chunk{chunks!.total !== 1 ? "s" : ""}
+            {chunkProgressLabel}
           </p>
         )}
       </div>

--- a/frontend-demo/app/lib/api.test.ts
+++ b/frontend-demo/app/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendMessage, ChatError } from "./api";
+import { sendMessage, ChatError, getDocumentStatus } from "./api";
 
 const MOCK_RESPONSE = {
   question: "What is RAG?",
@@ -88,6 +88,55 @@ describe("sendMessage", () => {
     await expect(sendMessage("q", "doc-123")).rejects.toThrow(ChatError);
     await expect(sendMessage("q", "doc-123")).rejects.toMatchObject({
       code: "unexpected",
+    });
+  });
+});
+
+describe("getDocumentStatus", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns numeric chunk progress from polling responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "embedding",
+          stage: "embedding",
+          chunks: { processed: 0, total: 24 },
+        }),
+        { status: 200 }
+      )
+    );
+
+    await expect(getDocumentStatus("/documents/doc-123/status")).resolves.toEqual({
+      status: "embedding",
+      stage: "embedding",
+      chunks: { processed: 0, total: 24 },
+    });
+  });
+
+  it("drops malformed chunk progress instead of passing it to the UI", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "embedding",
+          stage: "embedding",
+          chunks: { processed: "0", total: "24" },
+        }),
+        { status: 200 }
+      )
+    );
+
+    await expect(getDocumentStatus("/documents/doc-123/status")).resolves.toEqual({
+      status: "embedding",
+      stage: "embedding",
     });
   });
 });

--- a/frontend-demo/app/lib/chunkProgress.test.ts
+++ b/frontend-demo/app/lib/chunkProgress.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { formatChunkProgress, shouldShowChunkProgress } from "./chunkProgress";
+
+describe("formatChunkProgress", () => {
+  it("shows processed and total chunk progress", () => {
+    expect(formatChunkProgress({ processed: 7, total: 24 })).toBe(
+      "7 / 24 chunks"
+    );
+  });
+
+  it("shows zero processed chunks during early embedding progress", () => {
+    expect(formatChunkProgress({ processed: 0, total: 24 })).toBe(
+      "0 / 24 chunks"
+    );
+  });
+
+  it("uses the singular chunk label for one total chunk", () => {
+    expect(formatChunkProgress({ processed: 1, total: 1 })).toBe(
+      "1 / 1 chunk"
+    );
+  });
+});
+
+describe("shouldShowChunkProgress", () => {
+  it("shows progress only while the embedding stage is active", () => {
+    expect(
+      shouldShowChunkProgress({
+        stageKey: "embedding",
+        state: "active",
+        chunks: { processed: 0, total: 24 },
+      })
+    ).toBe(true);
+  });
+
+  it("hides progress outside the embedding stage", () => {
+    expect(
+      shouldShowChunkProgress({
+        stageKey: "chunking",
+        state: "active",
+        chunks: { processed: 7, total: 24 },
+      })
+    ).toBe(false);
+  });
+
+  it("hides stale progress after embedding is no longer active", () => {
+    expect(
+      shouldShowChunkProgress({
+        stageKey: "embedding",
+        state: "completed",
+        chunks: { processed: 24, total: 24 },
+      })
+    ).toBe(false);
+  });
+
+  it("hides progress when chunk data is missing", () => {
+    expect(
+      shouldShowChunkProgress({
+        stageKey: "embedding",
+        state: "active",
+      })
+    ).toBe(false);
+  });
+
+  it("hides progress for an empty total without rendering a stray zero", () => {
+    expect(
+      shouldShowChunkProgress({
+        stageKey: "embedding",
+        state: "active",
+        chunks: { processed: 0, total: 0 },
+      })
+    ).toBe(false);
+  });
+});

--- a/frontend-demo/app/lib/chunkProgress.ts
+++ b/frontend-demo/app/lib/chunkProgress.ts
@@ -1,0 +1,28 @@
+export type ChunkProgress = {
+  total: number;
+  processed: number;
+};
+
+type ChunkProgressStageState = "completed" | "active" | "pending" | "failed";
+
+export function formatChunkProgress(chunks: ChunkProgress) {
+  const chunkLabel = chunks.total === 1 ? "chunk" : "chunks";
+  return `${chunks.processed} / ${chunks.total} ${chunkLabel}`;
+}
+
+export function shouldShowChunkProgress({
+  stageKey,
+  state,
+  chunks,
+}: {
+  stageKey: string;
+  state: ChunkProgressStageState;
+  chunks?: ChunkProgress;
+}) {
+  return (
+    stageKey === "embedding" &&
+    state === "active" &&
+    !!chunks &&
+    chunks.total > 0
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Shows live embedding chunk progress in the frontend ingestion pipeline as `processed / total chunks`.

Closes #307

## Why?

The polling/SSE payload already includes both `chunks.processed` and `chunks.total`, but the UI only displayed the total. This made the embedding step look static even though progress was updating.

## Implementation notes

- Added a small chunk progress formatter and visibility helper.
- Kept progress visible only while the `embedding` stage is active.
- Avoided stale progress after the embedding stage completes.
- Guarded the `total: 0` edge case so React does not render a stray `0` text node.
- Added regression coverage for valid, missing, malformed, zero, singular, plural, and stale progress cases.

## How was it tested?

- [x] `cd frontend-demo && npm run test`
- [x] `cd frontend-demo && npm run lint`
- [x] `cd frontend-demo && npm run build`
- [x] `cd frontend-demo && npm run type-check`

## Screenshots

![Embedding progress screenshot](https://raw.githubusercontent.com/sourrris/chatvector-ai/pr-317-screenshot/.github/assets/embedding-progress-pr-317.jpg)
