### PR TITLE
docs: document ingestion status streaming in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -176,6 +176,26 @@ worker pool. Poll `GET /documents/{id}/status` for progress.
 queued → extracting → chunking → embedding → storing → completed
                                                       ↘ failed
 ```
+### Status updates: poll vs stream
+
+There are two ways to track ingestion progress after upload:
+
+**Poll:** `GET /documents/{document_id}/status`
+Standard JSON response. Works with any HTTP client and is the recommended
+fallback for simple integrations.
+
+**Stream:** `GET /documents/{document_id}/status/stream`
+Server-Sent Events (SSE). Requires `ENABLE_STREAMING=true` in
+`backend/.env` (see `backend/.env.example`). The event name is `status`;
+the payload shape matches the poll endpoint — same `status`, `chunks`,
+`error`, `timestamps`, and `queue_position` (when queued) fields.
+
+**Frontend demo behavior:** the demo client (`frontend-demo/app/lib/hooks/useDocumentPolling.ts`)
+tries the SSE stream first and falls back to polling automatically if the
+stream fails or streaming is disabled.
+
+> **Note:** The stream endpoint works by polling the database on a ~1 second
+> interval and emitting SSE events — it is not a push-from-worker channel yet.
 
 **Key config:**
 


### PR DESCRIPTION
## Summary

Added a "Status updates: poll vs stream" subsection to the Ingestion Queue section of `DEVELOPMENT.md`.

The section previously only documented the poll endpoint. This updated to show both options so integrators know that the SSE stream endpoint exists and subsequently understand how it behaves.

## Changes

- Documented `GET /documents/{document_id}/status` (poll) and `GET /documents/{document_id}/status/stream` (SSE stream)
- Noted the `ENABLE_STREAMING=true` requirement
- Described the SSE event name, payload shape, and frontend fallback behavior
- Included an honest note that the stream polls the DB on a ~1s interval and isn't a push-from-worker channel yet

## Final Checklist
- [x] Both poll and stream endpoints documented with correct paths
- [x] `ENABLE_STREAMING` requirement mentioned
- [x] SSE vs fallback behavior described accurately
- [x] No incorrect claims about real-time push from workers
- [x] Didn't rewrite the Ingestion Queue section or fiddle with ARCHITECTURE.md / README.md

Closes #316

@admaloch