### PR TITLE
feat: show error message text on pipeline stage failure

### DIFF
--- a/frontend-demo/app/chat/page.tsx
+++ b/frontend-demo/app/chat/page.tsx
@@ -90,6 +90,7 @@ export default function ChatPage() {
                     stage: poll.stage,
                     chunks: poll.chunks,
                     processingTime: poll.processingTime,
+                    errorMessage: poll.errorMessage,
                   }
                 : null
             }

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -21,6 +21,7 @@ type Props = {
   /** Chunk info surfaced during embedding stage. */
   chunks?: { total: number; processed: number };
   /** Fires each time the animated displayed stage advances, including the final "completed" tick. */
+  errorMessage?: string;
   onDisplayedStageChange?: (stage: string | undefined) => void;
 };
 
@@ -111,12 +112,14 @@ function StageRow({
   state,
   isLast,
   chunks,
+  errorMessage,
 }: {
   stageKey: string;
   label: string;
   state: StageState;
   isLast: boolean;
   chunks?: { total: number; processed: number };
+  errorMessage?: string;
 }) {
   const showChunks = shouldShowChunkProgress({ stageKey, state, chunks });
   const chunkProgressLabel =
@@ -182,6 +185,11 @@ function StageRow({
             {chunkProgressLabel}
           </p>
         )}
+          {state === "failed" && errorMessage && (
+           <p className="absolute top-full -mt-3 text-xs text-red-400/80">
+            {errorMessage.slice(0, 80)}
+          </p>
+        )}
       </div>
     </li>
   );
@@ -191,6 +199,7 @@ export default function IngestionPipeline({
   currentStage,
   failed = false,
   chunks,
+  errorMessage,
   onDisplayedStageChange,
 }: Props) {
   const { displayedStage, displayedCompleted } = useAnimatedStage(currentStage, failed);
@@ -217,6 +226,7 @@ export default function IngestionPipeline({
             state={state}
             isLast={isLast}
             chunks={chunks}
+            errorMessage={state === "failed" ? errorMessage : undefined}  
           />
         );
       })}

--- a/frontend-demo/app/components/IngestionPipeline.tsx
+++ b/frontend-demo/app/components/IngestionPipeline.tsx
@@ -185,8 +185,8 @@ function StageRow({
             {chunkProgressLabel}
           </p>
         )}
-          {state === "failed" && errorMessage && (
-           <p className="absolute top-full -mt-3 text-xs text-red-400/80">
+        {state === "failed" && errorMessage && (
+          <p className="absolute top-full -mt-3 text-xs text-red-400/80">
             {errorMessage.slice(0, 80)}
           </p>
         )}

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -264,7 +264,7 @@ export default function UploadModal({
                 <IngestionPipeline
                   currentStage={showUploading ? "uploading" : attachment?.stage}
                   failed={showServerFailed}
-                 chunks={attachment?.chunks}
+                  chunks={attachment?.chunks}
                   errorMessage={attachment?.errorMessage}
                   onDisplayedStageChange={(s) => {
                   if (s === "completed") setPipelineVisuallyComplete(true);

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -16,6 +16,7 @@ export type UploadModalAttachment = {
   stage?: string;
   chunks?: { total: number; processed: number };
   processingTime?: string;
+  errorMessage?: string;
 };
 
 type Props = {
@@ -263,11 +264,12 @@ export default function UploadModal({
                 <IngestionPipeline
                   currentStage={showUploading ? "uploading" : attachment?.stage}
                   failed={showServerFailed}
-                  chunks={attachment?.chunks}
+                 chunks={attachment?.chunks}
+                  errorMessage={attachment?.errorMessage}
                   onDisplayedStageChange={(s) => {
-                    if (s === "completed") setPipelineVisuallyComplete(true);
-                  }}
-                />
+                  if (s === "completed") setPipelineVisuallyComplete(true);
+                }}
+              />
                 {showServerFailed && (
                   <button
                     type="button"

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -267,9 +267,9 @@ export default function UploadModal({
                   chunks={attachment?.chunks}
                   errorMessage={attachment?.errorMessage}
                   onDisplayedStageChange={(s) => {
-                  if (s === "completed") setPipelineVisuallyComplete(true);
-                }}
-              />
+                    if (s === "completed") setPipelineVisuallyComplete(true);
+                  }}
+                />
                 {showServerFailed && (
                   <button
                     type="button"
@@ -330,12 +330,14 @@ export default function UploadModal({
                     >
                       {lastFile?.name ?? "Document"}
                     </p>
-                    <Loader2
-                      size={28}
-                      className="animate-spin text-muted"
-                      strokeWidth={2}
-                      aria-hidden
-                    />
+                    {!showServerFailed && (
+                      <Loader2
+                        size={28}
+                        className="animate-spin text-muted"
+                        strokeWidth={2}
+                        aria-hidden
+                      />
+                    )} 
                   </>
                 )}
               </div>

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -155,7 +155,7 @@ export type AttachmentState = {
 export type DocumentStatusPayload = {
   status: string;
   stage?: string;
-  error?: { stage?: string };
+  error?: { stage?: string; message?: string};
   chunks?: { total: number; processed: number } | null;
   created_at?: string | null;
   updated_at?: string | null;
@@ -185,7 +185,9 @@ export async function getDocumentStatus(
   const errorRaw = data?.error;
   const error =
     errorRaw != null && typeof errorRaw === "object"
-      ? { stage: (errorRaw as Record<string, unknown>).stage as string | undefined }
+      ? { stage: (errorRaw as Record<string, unknown>).stage as string | undefined,
+        message: (errorRaw as Record<string, unknown>).message as string | undefined
+       }
       : undefined;
   const createdAt = data?.created_at as string | null | undefined;
   const updatedAt = data?.updated_at as string | null | undefined;

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -155,7 +155,7 @@ export type AttachmentState = {
 export type DocumentStatusPayload = {
   status: string;
   stage?: string;
-  error?: { stage?: string; message?: string};
+  error?: { stage?: string; message?: string };
   chunks?: { total: number; processed: number } | null;
   created_at?: string | null;
   updated_at?: string | null;

--- a/frontend-demo/app/lib/hooks/useDocumentPolling.ts
+++ b/frontend-demo/app/lib/hooks/useDocumentPolling.ts
@@ -74,6 +74,7 @@ export function useDocumentPolling(
   chunks: { total: number; processed: number } | undefined;
   awaitingProcessing: boolean;
   processingTime: string | undefined;
+  errorMessage: string | undefined;
 } {
   const [polledUiStatus, setPolledUiStatus] = useState<
     PolledDocumentStatus | undefined
@@ -85,6 +86,7 @@ export function useDocumentPolling(
   >(undefined);
   const [awaitingProcessing, setAwaitingProcessing] = useState(false);
   const [processingTime, setProcessingTime] = useState<string | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
   // A toggle for environments/situations where SSE fails
   const [useFallbackPolling, setUseFallbackPolling] = useState(false);
@@ -105,6 +107,7 @@ export function useDocumentPolling(
       setAwaitingProcessing(false);
       setUseFallbackPolling(false);
       setProcessingTime(undefined);
+      setErrorMessage(undefined);
     }
   }, [docKey]);
 
@@ -135,6 +138,9 @@ export function useDocumentPolling(
           const rawStage = resolveDisplayStage(payload);
           setStage(rawStage);
           setCompletedStages(stagesBefore(rawStage));
+          if (payload.status === "failed") {
+           setErrorMessage(payload.error?.message ?? undefined);
+          }
 
           const c = payload.chunks;
           if (
@@ -201,6 +207,10 @@ export function useDocumentPolling(
           const rawStage = resolveDisplayStage(payload);
           setStage(rawStage);
           setCompletedStages(stagesBefore(rawStage));
+          if (payload.status === "failed") {
+           setErrorMessage(payload.error?.message ?? undefined);
+          }
+          
 
           const c = payload.chunks;
           if (
@@ -262,5 +272,6 @@ export function useDocumentPolling(
     chunks,
     awaitingProcessing: enabled && awaitingProcessing,
     processingTime,
+    errorMessage, 
   };
 }

--- a/frontend-demo/app/lib/hooks/useDocumentPolling.ts
+++ b/frontend-demo/app/lib/hooks/useDocumentPolling.ts
@@ -139,7 +139,7 @@ export function useDocumentPolling(
           setStage(rawStage);
           setCompletedStages(stagesBefore(rawStage));
           if (payload.status === "failed") {
-           setErrorMessage(payload.error?.message ?? undefined);
+           setErrorMessage(payload.error?.message);
           }
 
           const c = payload.chunks;
@@ -208,7 +208,7 @@ export function useDocumentPolling(
           setStage(rawStage);
           setCompletedStages(stagesBefore(rawStage));
           if (payload.status === "failed") {
-           setErrorMessage(payload.error?.message ?? undefined);
+           setErrorMessage(payload.error?.message);
           }
           
 


### PR DESCRIPTION
Closes #312

- Added `message?: string` to `DocumentStatusPayload.error` in `api.ts`
- Captured `error.message` in `useDocumentPolling` as `errorMessage` state
- Passed `errorMessage` through `UploadModal` to `IngestionPipeline`
- Rendered error message below failed stage row, truncated to 80 chars

@admaloch