### PR TITLE
Feat/batch query demo

### DIFF
--- a/frontend-demo/app/batch/page.tsx
+++ b/frontend-demo/app/batch/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Layers, Loader2, FileText, AlertCircle, CheckCircle2 } from "lucide-react";
+import {
+  sendBatchMessage,
+  ChatError,
+  type BatchResultItem,
+  type ChatSource,
+} from "../lib/api";
+import { getUploadedDocuments, type StoredDocument } from "../lib/documentStore";
+
+function deduplicatedSources(sources: ChatSource[]): ChatSource[] {
+  const seen = new Set<string>();
+  return sources.filter((s) => {
+    const key = `${s.file_name}::${s.page_number ?? "null"}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export default function BatchPage() {
+  const [documents, setDocuments] = useState<StoredDocument[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [question, setQuestion] = useState("");
+  const [inflight, setInflight] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [results, setResults] = useState<BatchResultItem[] | null>(null);
+  const [summary, setSummary] = useState<{
+    count: number;
+    success: number;
+    failure: number;
+  } | null>(null);
+
+  useEffect(() => {
+    setDocuments(getUploadedDocuments());
+  }, []);
+
+  const nameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const doc of documents) map.set(doc.documentId, doc.fileName);
+    return map;
+  }, [documents]);
+
+  const toggle = (documentId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(documentId)) next.delete(documentId);
+      else next.add(documentId);
+      return next;
+    });
+  };
+
+  const canSubmit = question.trim().length > 0 && selected.size > 0 && !inflight;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+    setResults(null);
+    setSummary(null);
+    setInflight(true);
+    try {
+      const docIds = documents
+        .map((d) => d.documentId)
+        .filter((id) => selected.has(id));
+      const response = await sendBatchMessage(question.trim(), docIds);
+      setResults(response.results);
+      setSummary({
+        count: response.count,
+        success: response.success_count,
+        failure: response.failure_count,
+      });
+    } catch (e) {
+      setError(
+        e instanceof ChatError ? e.message : "Something went wrong. Please try again."
+      );
+    } finally {
+      setInflight(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-10 text-foreground">
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-accent">
+          <Layers size={20} />
+          <span className="text-sm font-medium uppercase tracking-wide">
+            Batch Query
+          </span>
+        </div>
+        <h1 className="mt-2 text-3xl font-bold">Ask one question across many documents</h1>
+        <p className="mt-2 max-w-2xl text-muted">
+          Select documents you&apos;ve uploaded in the chat, enter a single
+          question, and ChatVector retrieves and answers from each one in
+          parallel — one answer card per document.
+        </p>
+      </div>
+
+      {documents.length === 0 ? (
+        <div className="rounded-xl border border-border bg-surface p-8 text-center">
+          <FileText className="mx-auto mb-3 text-muted" size={28} />
+          <p className="text-foreground">No documents yet.</p>
+          <p className="mt-1 text-sm text-muted">
+            Upload a document on the chat page first — it&apos;ll show up here
+            automatically.
+          </p>
+          <Link
+            href="/chat"
+            className="mt-4 inline-block rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Go to chat
+          </Link>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <div>
+            <label
+              htmlFor="batch-question"
+              className="mb-2 block text-sm font-medium"
+            >
+              Question
+            </label>
+            <textarea
+              id="batch-question"
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              rows={3}
+              placeholder="e.g. What are the key takeaways?"
+              className="w-full resize-y rounded-lg border border-border bg-surface px-4 py-3 text-base text-foreground outline-none focus:border-accent"
+            />
+          </div>
+
+          <div>
+            <p className="mb-2 text-sm font-medium">
+              Documents{" "}
+              <span className="font-normal text-muted">
+                ({selected.size} selected)
+              </span>
+            </p>
+            <ul className="flex flex-col gap-2">
+              {documents.map((doc) => (
+                <li key={doc.documentId}>
+                  <label className="flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3 transition-colors hover:border-accent">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(doc.documentId)}
+                      onChange={() => toggle(doc.documentId)}
+                      className="h-4 w-4 accent-[color:var(--accent)]"
+                    />
+                    <FileText size={16} className="shrink-0 text-muted" />
+                    <span className="truncate text-sm">{doc.fileName}</span>
+                    <span className="ml-auto truncate font-mono text-xs text-muted">
+                      {doc.documentId.slice(0, 8)}
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {inflight && <Loader2 size={16} className="animate-spin" />}
+              {inflight ? "Querying..." : "Run batch query"}
+            </button>
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-500">
+              <AlertCircle size={16} className="shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {summary && (
+            <div className="flex flex-wrap gap-4 rounded-lg border border-border bg-surface px-4 py-3 text-sm">
+              <span>
+                <strong>{summary.count}</strong> total
+              </span>
+              <span className="text-green-500">
+                <strong>{summary.success}</strong> succeeded
+              </span>
+              <span className={summary.failure > 0 ? "text-red-500" : "text-muted"}>
+                <strong>{summary.failure}</strong> failed
+              </span>
+            </div>
+          )}
+
+          {results && (
+            <div className="grid gap-4 md:grid-cols-2">
+              {results.map((result, i) => {
+                const docId = result.doc_ids[0];
+                const name = (docId && nameById.get(docId)) || docId || "Unknown document";
+                const isError = result.status === "error";
+                return (
+                  <div
+                    key={`${docId ?? "doc"}-${i}`}
+                    className={`flex flex-col gap-3 rounded-xl border p-4 ${
+                      isError ? "border-red-500/40 bg-red-500/5" : "border-border bg-surface"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      {isError ? (
+                        <AlertCircle size={16} className="shrink-0 text-red-500" />
+                      ) : (
+                        <CheckCircle2 size={16} className="shrink-0 text-green-500" />
+                      )}
+                      <span className="truncate text-sm font-medium" title={name}>
+                        {name}
+                      </span>
+                    </div>
+
+                    {isError ? (
+                      <p className="text-sm text-red-500">
+                        {result.error?.message ?? "This query failed."}
+                      </p>
+                    ) : (
+                      <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground">
+                        {result.answer || "No answer was generated."}
+                      </p>
+                    )}
+
+                    {result.sources && result.sources.length > 0 && (
+                      <div className="mt-auto flex flex-col gap-1 border-t border-border pt-2">
+                        {deduplicatedSources(result.sources).map((s, j) => (
+                          <span key={j} className="text-xs text-muted">
+                            {s.file_name}
+                            {s.page_number != null ? ` · p.${s.page_number}` : ""}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend-demo/app/batch/page.tsx
+++ b/frontend-demo/app/batch/page.tsx
@@ -165,7 +165,7 @@ export default function BatchPage() {
               type="button"
               onClick={handleSubmit}
               disabled={!canSubmit}
-              className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-accent px-5 py-2.5 font-medium text-surface transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {inflight && <Loader2 size={16} className="animate-spin" />}
               {inflight ? "Querying..." : "Run batch query"}

--- a/frontend-demo/app/components/Navigation.tsx
+++ b/frontend-demo/app/components/Navigation.tsx
@@ -12,6 +12,7 @@ const GITHUB_REPO = "https://github.com/chatvector-ai/chatvector-ai";
 const MAIN_NAV_LINKS = [
   { label: "About", href: "/about" },
   { label: "Chat", href: "/chat" },
+  { label: "Batch", href: "/batch" },
   { label: "Contributors", href: "/contributors" },
 ] as const;
 

--- a/frontend-demo/app/lib/api.test.ts
+++ b/frontend-demo/app/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendMessage, ChatError, getDocumentStatus } from "./api";
+import { sendMessage, sendBatchMessage, ChatError, getDocumentStatus } from "./api";
 
 const MOCK_RESPONSE = {
   question: "What is RAG?",
@@ -146,6 +146,82 @@ describe("sendMessage", () => {
 
     await expect(sendMessage("q", "doc-123")).rejects.toThrow(ChatError);
     await expect(sendMessage("q", "doc-123")).rejects.toMatchObject({
+      code: "unexpected",
+    });
+  });
+});
+
+describe("sendBatchMessage", () => {
+  const originalFetch = globalThis.fetch;
+
+  const BATCH_RESPONSE = {
+    count: 2,
+    success_count: 1,
+    failure_count: 1,
+    results: [
+      {
+        status: "ok",
+        question: "Summary?",
+        doc_ids: ["doc-1"],
+        chunks: 2,
+        answer: "First summary.",
+        sources: [{ file_name: "a.pdf", page_number: 1, chunk_index: 0 }],
+      },
+      {
+        status: "error",
+        question: "Summary?",
+        doc_ids: ["doc-2"],
+        chunks: 0,
+        error: { code: "query_processing_failed", message: "boom" },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sends one query item per document and returns parsed results", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify(BATCH_RESPONSE), { status: 200 })
+    );
+
+    const result = await sendBatchMessage("Summary?", ["doc-1", "doc-2"]);
+
+    expect(result).toEqual(BATCH_RESPONSE);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/chat/batch"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          queries: [
+            { question: "Summary?", doc_ids: ["doc-1"], match_count: 5 },
+            { question: "Summary?", doc_ids: ["doc-2"], match_count: 5 },
+          ],
+          session_id: "test-session-id",
+        }),
+      })
+    );
+  });
+
+  it("throws backend_unreachable on network failure", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(sendBatchMessage("q", ["doc-1"])).rejects.toMatchObject({
+      name: "ChatError",
+      code: "backend_unreachable",
+    });
+  });
+
+  it("throws unexpected on a 500 response", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 500 }));
+
+    await expect(sendBatchMessage("q", ["doc-1"])).rejects.toMatchObject({
+      name: "ChatError",
       code: "unexpected",
     });
   });

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -199,6 +199,86 @@ export async function getDocumentStatus(
   };
 }
 
+export type BatchResultItem = {
+  status: "ok" | "error";
+  question: string;
+  doc_ids: string[];
+  chunks?: number;
+  answer?: string;
+  sources?: ChatSource[];
+  error?: { code: string; message: string };
+};
+
+export type BatchChatResponse = {
+  count: number;
+  success_count: number;
+  failure_count: number;
+  results: BatchResultItem[];
+};
+
+/**
+ * Query the same question against several documents in one request via
+ * `POST /chat/batch`. Each document becomes its own query item, so the response
+ * contains one result per document (in the same order as `docIds`).
+ */
+export async function sendBatchMessage(
+  question: string,
+  docIds: string[],
+  matchCount = 5,
+  sessionIdOverride?: string | null
+): Promise<BatchChatResponse> {
+  const sessionId =
+    sessionIdOverride !== undefined ? sessionIdOverride : getSessionId();
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (sessionId !== null) {
+    headers["X-Session-Id"] = sessionId;
+  }
+
+  const body: Record<string, unknown> = {
+    queries: docIds.map((docId) => ({
+      question,
+      doc_ids: [docId],
+      match_count: matchCount,
+    })),
+  };
+  if (sessionId !== null) {
+    body.session_id = sessionId;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/chat/batch`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new ChatError(
+      "backend_unreachable",
+      "Cannot reach the server. Check your connection."
+    );
+  }
+
+  if (res.status === 429) {
+    throw new ChatError(
+      "unexpected",
+      "Too many requests — please wait a moment and try again."
+    );
+  }
+
+  if (!res.ok) {
+    throw new ChatError(
+      "unexpected",
+      `Server error (${res.status}). Please try again.`
+    );
+  }
+
+  return (await res.json()) as BatchChatResponse;
+}
+
 export async function uploadDocument(
   file: File
 ): Promise<{ documentId: string; statusEndpoint: string }> {

--- a/frontend-demo/app/lib/documentStore.ts
+++ b/frontend-demo/app/lib/documentStore.ts
@@ -1,0 +1,60 @@
+const STORAGE_KEY = "chatvector_uploaded_documents";
+const MAX_ENTRIES = 50;
+
+export type StoredDocument = {
+  documentId: string;
+  fileName: string;
+  uploadedAt: number;
+};
+
+function isStoredDocument(value: unknown): value is StoredDocument {
+  if (value == null || typeof value !== "object") return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.documentId === "string" &&
+    o.documentId.length > 0 &&
+    typeof o.fileName === "string" &&
+    typeof o.uploadedAt === "number"
+  );
+}
+
+function read(): StoredDocument[] {
+  if (typeof window === "undefined") return [];
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isStoredDocument);
+  } catch (e) {
+    console.warn("Failed to parse uploaded documents from localStorage", e);
+    return [];
+  }
+}
+
+function write(documents: StoredDocument[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(documents));
+}
+
+export function getUploadedDocuments(): StoredDocument[] {
+  return read().sort((a, b) => b.uploadedAt - a.uploadedAt);
+}
+
+export function saveUploadedDocument(doc: {
+  documentId: string;
+  fileName: string;
+}): void {
+  if (!doc.documentId) return;
+  const existing = read().filter((d) => d.documentId !== doc.documentId);
+  const next: StoredDocument[] = [
+    { documentId: doc.documentId, fileName: doc.fileName, uploadedAt: Date.now() },
+    ...existing,
+  ].slice(0, MAX_ENTRIES);
+  write(next);
+}
+
+export function removeUploadedDocument(documentId: string): void {
+  if (!documentId) return;
+  write(read().filter((d) => d.documentId !== documentId));
+}

--- a/frontend-demo/app/lib/hooks/useChat.ts
+++ b/frontend-demo/app/lib/hooks/useChat.ts
@@ -9,6 +9,10 @@ import {
   type Message,
 } from "../api";
 import { useDocumentPolling } from "./useDocumentPolling";
+import {
+  saveUploadedDocument,
+  removeUploadedDocument,
+} from "../documentStore";
 
 const welcomeMessages: Message[] = [
   {
@@ -186,6 +190,7 @@ export function useChat(sessionId: string | null) {
     if (!attachment) return;
     const out = await deleteDocument(attachment.documentId);
     if (out === "gone") {
+      removeUploadedDocument(attachment.documentId);
       setAttachment(null);
       setRemoveError(null);
       return;
@@ -204,6 +209,10 @@ export function useChat(sessionId: string | null) {
     statusEndpoint: string;
   }) => {
     setRemoveError(null);
+    saveUploadedDocument({
+      documentId: payload.documentId,
+      fileName: payload.fileName,
+    });
     setAttachment({
       fileName: payload.fileName,
       documentId: payload.documentId,
@@ -218,6 +227,7 @@ export function useChat(sessionId: string | null) {
     try {
       const out = await deleteDocument(attachment.documentId);
       if (out === "gone") {
+        removeUploadedDocument(attachment.documentId);
         setAttachment(null);
         return;
       }


### PR DESCRIPTION
## What does this PR do?

Adds a **Batch Query** demo page (`/batch`) that exercises `POST /chat/batch` —
the API's most powerful endpoint, which was previously never called by the
frontend demo. The page lets you ask a single question across multiple
documents at once and shows one answer card per document, making ChatVector's
parallel multi-document retrieval visible and interactive.

### Highlights

- **New `/batch` page** (`app/batch/page.tsx`): question box, document
  checkbox picker, an aggregate summary (total / succeeded / failed), and a
  grid of per-document result cards (answer + source citations).
- **Per-result error handling**: a failed query renders a red failure card
  with its error message; other cards in the same batch are unaffected.
- **API client**: new `sendBatchMessage()` plus `BatchResultItem` /
  `BatchChatResponse` types in `app/lib/api.ts`. Each selected document is sent
  as its own query item, so results map 1:1 to documents.
- **Navigation**: added a **Batch** link to the main nav.

### Document selection approach

There is no `GET /documents` list endpoint, so the page needs another source of
document IDs. Following the issue's suggested solution, I added a small
localStorage registry (`app/lib/documentStore.ts`): when a user uploads a
document in the chat flow it's saved as `{ documentId, fileName }`, and the
batch page reads that list to render the checkboxes. Documents are removed from
the store when deleted from chat, keeping the list in sync. The store dedupes
by ID, caps entries, and is SSR-safe.

### Out of scope (per the issue's non-goals)

No persistent batch history, no upload from this page, no streaming, no
advanced document management UI.

## How was it tested?

- [x] Tested locally with FastAPI `/docs`
- [x] Checked existing functionality still works

Details:
- `npm run lint` → no ESLint warnings or errors
- `npx vitest run` → 16/16 pass (3 new tests covering `sendBatchMessage`
  success shape, network failure, and a 500 response)
- `npm run build` → compiles cleanly; `/batch` route generated
- Manual: uploaded a document on `/chat`, opened `/batch`, selected it,
  submitted a question, and confirmed per-document answers, citations, the
  summary counts, and a graceful failure card for an errored query.

## Screenshots (if UI changes):

# Before uploading documents in chat page

<img width="1665" height="870" alt="image" src="https://github.com/user-attachments/assets/5302e19e-2a39-4108-a2cc-a5793e5df752" />

# After uploading documents in chat page

<img width="1474" height="778" alt="image" src="https://github.com/user-attachments/assets/1b537bc9-a4d2-4b09-9f25-f81404d8ad2e" />

# After querying the results

<img width="1460" height="857" alt="image" src="https://github.com/user-attachments/assets/ba3263f6-ed57-4ba7-a40b-c11e5a0299d3" />
