### PR TITLE
feat: show upload queue position in attachment chip

### DIFF
--- a/frontend-demo/app/components/AttachmentChip.tsx
+++ b/frontend-demo/app/components/AttachmentChip.tsx
@@ -9,6 +9,7 @@ type Props = {
   stage?: string;
   chunks?: { total: number; processed: number };
   awaitingProcessing?: boolean;
+  queuePosition?: number;
   processingTime?: string;
   onRemove: () => void;
 };
@@ -55,6 +56,7 @@ export default function AttachmentChip({
   stage,
   chunks,
   awaitingProcessing = false,
+  queuePosition,
   processingTime,
   onRemove,
 }: Props) {
@@ -67,28 +69,44 @@ export default function AttachmentChip({
   );
   const tone = iconAndTextClass(status);
 
+  // Surface the upload queue position only while the document waits its turn.
+  // Once polling reports active progress (awaitingProcessing flips false) the
+  // stage label takes over, and position 1 needs no indicator.
+  const showQueuePosition =
+    status === "processing" &&
+    awaitingProcessing &&
+    typeof queuePosition === "number" &&
+    queuePosition > 1;
+
   return (
-    <div className="flex w-fit max-w-full items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2">
-      <FileText size={14} className={`shrink-0 ${tone}`} />
-      <span className="shrink-0 text-xs text-muted">Active document:</span>
-      <span
-        className={`min-w-0 max-w-[min(100%,14rem)] truncate text-xs font-medium sm:max-w-[18rem] ${tone}`}
-      >
-        {label}
-      </span>
-      {status === "ready" && processingTime && (
-        <span className="shrink-0 text-[10px] text-subtle" title={`Processed in ${processingTime}`}>
-          {processingTime}
+    <div className="flex w-fit max-w-full flex-col gap-0.5 rounded-lg border border-border bg-surface px-3 py-2">
+      <div className="flex items-center gap-2">
+        <FileText size={14} className={`shrink-0 ${tone}`} />
+        <span className="shrink-0 text-xs text-muted">Active document:</span>
+        <span
+          className={`min-w-0 max-w-[min(100%,14rem)] truncate text-xs font-medium sm:max-w-[18rem] ${tone}`}
+        >
+          {label}
+        </span>
+        {status === "ready" && processingTime && (
+          <span className="shrink-0 text-[10px] text-subtle" title={`Processed in ${processingTime}`}>
+            {processingTime}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="shrink-0 rounded-md p-1 text-muted transition hover:bg-background hover:text-foreground"
+          aria-label="Remove attachment"
+        >
+          <X size={16} />
+        </button>
+      </div>
+      {showQueuePosition && (
+        <span className="text-[10px] text-subtle">
+          Position {queuePosition} in queue
         </span>
       )}
-      <button
-        type="button"
-        onClick={onRemove}
-        className="shrink-0 rounded-md p-1 text-muted transition hover:bg-background hover:text-foreground"
-        aria-label="Remove attachment"
-      >
-        <X size={16} />
-      </button>
     </div>
   );
 }

--- a/frontend-demo/app/components/UploadModal.tsx
+++ b/frontend-demo/app/components/UploadModal.tsx
@@ -9,6 +9,7 @@ export type UploadAcceptedPayload = {
   fileName: string;
   documentId: string;
   statusEndpoint: string;
+  queuePosition?: number;
 };
 
 export type UploadModalAttachment = {
@@ -78,8 +79,14 @@ export default function UploadModal({
       if (onBeforeUpload) {
         await onBeforeUpload();
       }
-      const { documentId, statusEndpoint } = await uploadDocument(file);
-      onUploadAccepted({ fileName: file.name, documentId, statusEndpoint });
+      const { documentId, statusEndpoint, queuePosition } =
+        await uploadDocument(file);
+      onUploadAccepted({
+        fileName: file.name,
+        documentId,
+        statusEndpoint,
+        queuePosition,
+      });
       setAwaitingProcessing(true);
     } catch (err) {
       setUploadHttpFailed(true);

--- a/frontend-demo/app/components/chat/ChatInput.tsx
+++ b/frontend-demo/app/components/chat/ChatInput.tsx
@@ -60,6 +60,7 @@ export default function ChatInput({
             stage={poll.stage}
             chunks={poll.chunks}
             awaitingProcessing={poll.awaitingProcessing}
+            queuePosition={attachment.queue_position}
             processingTime={poll.processingTime}
             onRemove={() => void handleRemoveAttachment()}
           />

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -150,6 +150,7 @@ export type AttachmentState = {
   status: "processing" | "ready" | "failed";
   stage?: string;
   chunks?: { total: number; processed: number };
+  queue_position?: number;
 };
 
 export type DocumentStatusPayload = {
@@ -201,7 +202,7 @@ export async function getDocumentStatus(
 
 export async function uploadDocument(
   file: File
-): Promise<{ documentId: string; statusEndpoint: string }> {
+): Promise<{ documentId: string; statusEndpoint: string; queuePosition: number }> {
   const sessionId = getSessionId();
   const formData = new FormData();
   formData.append("file", file);
@@ -235,8 +236,9 @@ export async function uploadDocument(
   const data = await res.json();
   const documentId = data?.document_id as string | undefined;
   const statusEndpoint = data?.status_endpoint as string | undefined;
-  if (!documentId || !statusEndpoint) {
+  const queuePosition = data?.queue_position as unknown;
+  if (!documentId || !statusEndpoint || typeof queuePosition !== "number") {
     throw new Error("Invalid upload response from server.");
   }
-  return { documentId, statusEndpoint };
+  return { documentId, statusEndpoint, queuePosition };
 }

--- a/frontend-demo/app/lib/api.ts
+++ b/frontend-demo/app/lib/api.ts
@@ -202,7 +202,7 @@ export async function getDocumentStatus(
 
 export async function uploadDocument(
   file: File
-): Promise<{ documentId: string; statusEndpoint: string; queuePosition: number }> {
+): Promise<{ documentId: string; statusEndpoint: string; queuePosition?: number }> {
   const sessionId = getSessionId();
   const formData = new FormData();
   formData.append("file", file);
@@ -236,8 +236,9 @@ export async function uploadDocument(
   const data = await res.json();
   const documentId = data?.document_id as string | undefined;
   const statusEndpoint = data?.status_endpoint as string | undefined;
-  const queuePosition = data?.queue_position as unknown;
-  if (!documentId || !statusEndpoint || typeof queuePosition !== "number") {
+  const queuePosition =
+    typeof data?.queue_position === "number" ? data.queue_position : undefined;
+  if (!documentId || !statusEndpoint) {
     throw new Error("Invalid upload response from server.");
   }
   return { documentId, statusEndpoint, queuePosition };

--- a/frontend-demo/app/lib/hooks/useChat.ts
+++ b/frontend-demo/app/lib/hooks/useChat.ts
@@ -202,6 +202,7 @@ export function useChat(sessionId: string | null) {
     fileName: string;
     documentId: string;
     statusEndpoint: string;
+    queuePosition?: number;
   }) => {
     setRemoveError(null);
     setAttachment({
@@ -209,6 +210,7 @@ export function useChat(sessionId: string | null) {
       documentId: payload.documentId,
       statusEndpoint: payload.statusEndpoint,
       status: "processing",
+      queue_position: payload.queuePosition,
     });
   };
 


### PR DESCRIPTION
Closes #308

Thread the queue_position returned by POST /upload through the upload flow so the attachment chip shows "Position N in queue" while a document waits behind others. The line is hidden once active processing begins and is not shown for position 1.
